### PR TITLE
Rust 1.12.0 support and automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,20 @@ However, using pre-built tools has advantages:
     basic, stable recipe features are used.
   * Trivial support for all architectures supported by upstream Rust.
 
-## Adding Support for new Versions
+## Adding Support for New Versions
 
 When a new version of rust is released, adding support for this new version can
 be done by running `build-new-version.sh` as follows:
 
-    ./build-new-version.sh <version> recipes-devtools/rust/rust-bin_<version>.bb
+    ./build-new-version.sh <version>
+
+This will create two new recipes:
+ - recipes-devtools/rust/rust-bin-<version>.bb
+ - recipes-devtools/rust/cargo-bin-<date>.bb
+
+ Where the cargo version generated is the one packaged with the associated
+ release of rust itself (using the published channel data consumed by other
+ tools like rustup).
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ However, using pre-built tools has advantages:
     basic, stable recipe features are used.
   * Trivial support for all architectures supported by upstream Rust.
 
+## Adding Support for new Versions
+
+When a new version of rust is released, adding support for this new version can
+be done by running `build-new-version.sh` as follows:
+
+    ./build-new-version.sh <version> recipes-devtools/rust/rust-bin_<version>.bb
 
 ## Copyright
 

--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+#
+# This script can be run to add a new version of rust to those supported
+# in the project.  It automates away some of the tedium of working
+# through checksum failures one-by-one.
+
+set -e
+
+TARGET_VERSION="$1"
+if [ -z "$TARGET_VERSION" ]; then
+    >&2 echo "Must specify a target version as first argument"
+    exit 1
+fi
+
+OUT="$2"
+if [ -z "$OUT" ]; then
+    >&2 echo "Must specify an output file as the second argument"
+    exit 1
+else
+    OUT=$(realpath "$OUT")
+fi
+
+echo "">${OUT}
+
+TMPDIR=`mktemp -d`
+cd "$TMPDIR"
+
+TARGET_TRIPLES="\
+aarch64-unknown-linux-gnu
+arm-unknown-linux-gnueabi
+arm-unknown-linux-gnueabihf
+armv7-unknown-linux-gnueabihf
+i686-unknown-linux-gnu
+mips-unknown-linux-gnu
+mipsel-unknown-linux-gnu
+powerpc-unknown-linux-gnu
+powerpc64-unknown-linux-gnu
+x86_64-unknown-linux-gnu"
+
+RUSTC_TRIPLES="\
+aarch64-unknown-linux-gnu
+arm-unknown-linux-gnueabi
+arm-unknown-linux-gnueabihf
+armv7-unknown-linux-gnueabihf
+i686-unknown-linux-gnu
+x86_64-unknown-linux-gnu"
+
+dlfile() {
+    component="$1"
+    triple="$2"
+    echo "Downloading $component for triple $triple..."
+    wget https://static.rust-lang.org/dist/${component}-${TARGET_VERSION}-${triple}.tar.gz
+}
+
+get_md5sum() {
+    component="$1"
+    triple="$2"
+    md5sum ${component}-${TARGET_VERSION}-${triple}.tar.gz | cut -d' ' -f1
+}
+
+get_sha256() {
+    component="$1"
+    triple="$2"
+    sha256sum ${component}-${TARGET_VERSION}-${triple}.tar.gz | cut -d' ' -f1
+}
+
+download_files() {
+    for triple in $RUSTC_TRIPLES; do
+        dlfile rustc ${triple}
+    done
+
+    for triple in $TARGET_TRIPLES; do
+        dlfile rust-std ${triple}
+    done
+}
+
+write_get_hash() {
+    cat <<EOF >>${OUT}
+def get_hash(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+
+EOF
+}
+
+write_std_md5() {
+    cat <<EOF >>${OUT}
+def rust_std_md5(triple):
+    HASHES = {
+EOF
+    for triple in $TARGET_TRIPLES; do
+        echo >>${OUT} "        \"$triple\": \"$(get_md5sum rust-std $triple)\","
+    done
+    cat <<EOF >>${OUT}
+    }
+    return get_hash(HASHES, triple)
+
+EOF
+}
+
+
+write_std_sha256() {
+    cat <<EOF >>${OUT}
+def rust_std_sha256(triple):
+    HASHES = {
+EOF
+    for triple in $TARGET_TRIPLES; do
+        echo >>${OUT} "        \"$triple\": \"$(get_sha256 rust-std $triple)\","
+    done
+
+    cat <<EOF >>${OUT}
+    }
+    return get_hash(HASHES, triple)
+
+EOF
+}
+
+write_rustc_md5() {
+    cat <<EOF >>${OUT}
+def rustc_md5(triple):
+    HASHES = {
+EOF
+    for triple in $RUSTC_TRIPLES; do
+        echo >>${OUT} "        \"$triple\": \"$(get_md5sum rustc $triple)\","
+    done
+    cat <<EOF >>${OUT}
+    }
+    return get_hash(HASHES, triple)
+
+EOF
+}
+
+write_rustc_sha256() {
+    cat <<EOF >>${OUT}
+def rustc_sha256(triple):
+    HASHES = {
+EOF
+    for triple in $RUSTC_TRIPLES; do
+        echo >>${OUT} "        \"$triple\": \"$(get_sha256 rustc $triple)\","
+    done
+    cat >>${OUT} <<EOF
+    }
+    return get_hash(HASHES, triple)
+
+EOF
+}
+
+write_final_contents() {
+    cat <<EOF >>${OUT}
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
+
+include rust-bin.inc
+EOF
+}
+
+download_files
+write_get_hash
+write_std_md5
+write_std_sha256
+write_rustc_md5
+write_rustc_sha256
+write_final_contents
+
+cd -
+rm -rf ${TMPDIR}

--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -6,23 +6,15 @@
 
 set -e
 
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 TARGET_VERSION="$1"
 if [ -z "$TARGET_VERSION" ]; then
     >&2 echo "Must specify a target version as first argument"
     exit 1
 fi
 
-OUT="$2"
-if [ -z "$OUT" ]; then
-    >&2 echo "Must specify an output file as the second argument"
-    exit 1
-else
-    OUT=$(realpath "$OUT")
-fi
-
-echo "">${OUT}
-
-TMPDIR=`mktemp -d`
+TMPDIR=`mktemp -p $PWD -d`
 cd "$TMPDIR"
 
 TARGET_TRIPLES="\
@@ -53,29 +45,68 @@ dlfile() {
 }
 
 get_md5sum() {
-    component="$1"
-    triple="$2"
-    md5sum ${component}-${TARGET_VERSION}-${triple}.tar.gz | cut -d' ' -f1
+    md5sum $1 | cut -d ' ' -f1
 }
 
-get_sha256() {
+get_sha256sum() {
+    sha256sum $1 | cut -d ' ' -f1
+}
+
+get_rust_md5sum() {
     component="$1"
     triple="$2"
-    sha256sum ${component}-${TARGET_VERSION}-${triple}.tar.gz | cut -d' ' -f1
+    get_md5sum ${component}-${TARGET_VERSION}-${triple}.tar.gz
+}
+
+get_rust_sha256sum() {
+    component="$1"
+    triple="$2"
+    get_sha256sum ${component}-${TARGET_VERSION}-${triple}.tar.gz
 }
 
 download_files() {
+    # channel file
+    local channel_file="channel-rust-${TARGET_VERSION}.toml"
+    wget https://static.rust-lang.org/dist/${channel_file}
+
+    # cargo for each supported host triple
+    for triple in $RUSTC_TRIPLES; do
+        url=$(grep -A 3 "pkg.cargo.target.${triple}" ${channel_file} | \
+                     grep '^url =' | \
+                     cut -d '=' -f2 | \
+                     tr -d '"')
+        wget ${url}
+    done
+
+    # rustc
     for triple in $RUSTC_TRIPLES; do
         dlfile rustc ${triple}
     done
 
+    # rust-std
     for triple in $TARGET_TRIPLES; do
         dlfile rust-std ${triple}
     done
 }
 
+cargo_version() {
+    grep -A 3 "pkg.cargo.target.x86_64-unknown-linux-gnu" "channel-rust-${TARGET_VERSION}.toml" | \
+        grep '^url =' | \
+        cut -d'=' -f2 | \
+        tr -d '"' | \
+        rev | \
+        cut -d'/' -f2 | \
+        rev | \
+        tr -d '-'
+}
+
+cargo_filename() {
+    triple="$1"
+    echo "cargo-nightly-${triple}.tar.gz"
+}
+
 write_get_hash() {
-    cat <<EOF >>${OUT}
+    cat <<EOF >>${RUST_BIN_RECIPE}
 def get_hash(hashes, triple):
     try:
         return hashes[triple]
@@ -87,14 +118,14 @@ EOF
 }
 
 write_std_md5() {
-    cat <<EOF >>${OUT}
+    cat <<EOF >>${RUST_BIN_RECIPE}
 def rust_std_md5(triple):
     HASHES = {
 EOF
     for triple in $TARGET_TRIPLES; do
-        echo >>${OUT} "        \"$triple\": \"$(get_md5sum rust-std $triple)\","
+        echo >>${RUST_BIN_RECIPE} "        \"$triple\": \"$(get_rust_md5sum rust-std $triple)\","
     done
-    cat <<EOF >>${OUT}
+    cat <<EOF >>${RUST_BIN_RECIPE}
     }
     return get_hash(HASHES, triple)
 
@@ -103,15 +134,15 @@ EOF
 
 
 write_std_sha256() {
-    cat <<EOF >>${OUT}
+    cat <<EOF >>${RUST_BIN_RECIPE}
 def rust_std_sha256(triple):
     HASHES = {
 EOF
     for triple in $TARGET_TRIPLES; do
-        echo >>${OUT} "        \"$triple\": \"$(get_sha256 rust-std $triple)\","
+        echo >>${RUST_BIN_RECIPE} "        \"$triple\": \"$(get_rust_sha256sum rust-std $triple)\","
     done
 
-    cat <<EOF >>${OUT}
+    cat <<EOF >>${RUST_BIN_RECIPE}
     }
     return get_hash(HASHES, triple)
 
@@ -119,14 +150,14 @@ EOF
 }
 
 write_rustc_md5() {
-    cat <<EOF >>${OUT}
+    cat <<EOF >>${RUST_BIN_RECIPE}
 def rustc_md5(triple):
     HASHES = {
 EOF
     for triple in $RUSTC_TRIPLES; do
-        echo >>${OUT} "        \"$triple\": \"$(get_md5sum rustc $triple)\","
+        echo >>${RUST_BIN_RECIPE} "        \"$triple\": \"$(get_rust_md5sum rustc $triple)\","
     done
-    cat <<EOF >>${OUT}
+    cat <<EOF >>${RUST_BIN_RECIPE}
     }
     return get_hash(HASHES, triple)
 
@@ -134,14 +165,14 @@ EOF
 }
 
 write_rustc_sha256() {
-    cat <<EOF >>${OUT}
+    cat <<EOF >>${RUST_BIN_RECIPE}
 def rustc_sha256(triple):
     HASHES = {
 EOF
     for triple in $RUSTC_TRIPLES; do
-        echo >>${OUT} "        \"$triple\": \"$(get_sha256 rustc $triple)\","
+        echo >>${RUST_BIN_RECIPE} "        \"$triple\": \"$(get_rust_sha256sum rustc $triple)\","
     done
-    cat >>${OUT} <<EOF
+    cat >>${RUST_BIN_RECIPE} <<EOF
     }
     return get_hash(HASHES, triple)
 
@@ -149,20 +180,71 @@ EOF
 }
 
 write_final_contents() {
-    cat <<EOF >>${OUT}
+    cat <<EOF >>${RUST_BIN_RECIPE}
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 
 include rust-bin.inc
 EOF
 }
 
+write_cargo_recipe() {
+    cat <<EOF >>${CARGO_BIN_RECIPE}
+def get_hash(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+EOF
+    for triple in $RUSTC_TRIPLES; do
+        echo >>${CARGO_BIN_RECIPE} "        \"$triple\": \"$(get_md5sum $(cargo_filename $triple))\","
+    done
+    cat <<EOF >>${CARGO_BIN_RECIPE}
+    }
+    return get_hash(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+EOF
+    for triple in $RUSTC_TRIPLES; do
+        echo >>${CARGO_BIN_RECIPE} "        \"$triple\": \"$(get_sha256sum $(cargo_filename $triple))\","
+    done
+
+    cat <<EOF >>${CARGO_BIN_RECIPE}
+    }
+    return get_hash(HASHES, triple)
+
+DEPENDS += "rust-bin (= ${TARGET_VERSION})"
+LIC_FILES_CHKSUM = "\\
+    file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \\
+    file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \\
+"
+
+include cargo-bin.inc
+EOF
+}
+
 download_files
+
+RUST_BIN_RECIPE="${ROOT_DIR}/recipes-devtools/rust/rust-bin_${TARGET_VERSION}.bb"
+CARGO_BIN_RECIPE="${ROOT_DIR}/recipes-devtools/rust/cargo-bin_$(cargo_version).bb"
+
+# create/clear files
+echo "" >${RUST_BIN_RECIPE}
+echo "" >${CARGO_BIN_RECIPE}
+
+# write the rust-bin recipe
 write_get_hash
 write_std_md5
 write_std_sha256
 write_rustc_md5
 write_rustc_sha256
 write_final_contents
+
+# write the cargo recipe
+write_cargo_recipe
 
 cd -
 rm -rf ${TMPDIR}

--- a/recipes-devtools/rust/cargo-bin.inc
+++ b/recipes-devtools/rust/cargo-bin.inc
@@ -22,8 +22,9 @@ python () {
     pv = d.getVar("PV", True)
     pv_uri = pv[0:4] + '-' + pv[4:6] + '-' + pv[6:8]
     target = d.getVar("CARGO_HOST_TARGET", True)
-    cargo_uri = ("%s/cargo-dist/%s/cargo-nightly-%s.tar.gz;md5sum=%s;sha256sum=%s" %
-                 (base_uri, pv_uri, target, cargo_md5(target), cargo_sha256(target)))
+    cargo_uri = ("%s/cargo-dist/%s/cargo-nightly-%s.tar.gz;md5sum=%s;sha256sum=%s;downloadname=%s" %
+                 (base_uri, pv_uri, target, cargo_md5(target), cargo_sha256(target),
+                  d.getVar("PN", True) + "-" + pv + "-" + target + ".tar.gz"))
     src_uri = d.getVar("SRC_URI", True).split()
     d.setVar("SRC_URI", ' '.join(src_uri + [cargo_uri]))
 }

--- a/recipes-devtools/rust/cargo-bin_20160821.bb
+++ b/recipes-devtools/rust/cargo-bin_20160821.bb
@@ -1,0 +1,36 @@
+
+def get_hash(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "c146f696a277de6e9cc8599fa671564e",
+        "arm-unknown-linux-gnueabi": "5f522ca2ba1a8c2bf7f5708823d19b2e",
+        "arm-unknown-linux-gnueabihf": "1a62e360a6620643c88f43be09c530b5",
+        "armv7-unknown-linux-gnueabihf": "2bf99a05a400a63ec5b7dea99dbb9442",
+        "i686-unknown-linux-gnu": "6b1ecfcdf8f04c596a66e04b50319a92",
+        "x86_64-unknown-linux-gnu": "db8f4a71394eb2d02d9b467821847f93",
+    }
+    return get_hash(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "f7bb5adc3c2c252d0cca2bf998f3f34867ea15aa49a23d77de2014ce2da49df8",
+        "arm-unknown-linux-gnueabi": "4aed27a752d3023c85ea7cbb5d102239bc562a3a8e0635ba1eeed645f604c8f8",
+        "arm-unknown-linux-gnueabihf": "2d27879622433e819cee8c3a68fdb34edcac9d5469bd338e00e97594b0132d04",
+        "armv7-unknown-linux-gnueabihf": "abdf624436090239d27466ebd33c44245acf65337e510ed24c41567e02bace45",
+        "i686-unknown-linux-gnu": "46f22e9333f64d2aeff34be0a180b3a49b5a68e9f4a9cae8fe2814590f5a30a5",
+        "x86_64-unknown-linux-gnu": "bf91da07e7cf81c5ba2d0fc453cb21edbf0d26def4f1a28093bf10851cc017c0",
+    }
+    return get_hash(HASHES, triple)
+
+DEPENDS += "rust-bin (= 1.12.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
+    file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
+"
+
+include cargo-bin.inc

--- a/recipes-devtools/rust/rust-bin_1.12.0.bb
+++ b/recipes-devtools/rust/rust-bin_1.12.0.bb
@@ -1,0 +1,63 @@
+
+def get_hash(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "91f604ac62e01bf13f15dc1ff98ffb06",
+        "arm-unknown-linux-gnueabi": "aba7c1c7d373b48660534daadb09aff0",
+        "arm-unknown-linux-gnueabihf": "d3745dedaa6d2aaef1613fafa5c009c8",
+        "armv7-unknown-linux-gnueabihf": "230a92b7569846686d18c9cbc22fcc5a",
+        "i686-unknown-linux-gnu": "aebfe6a871a2da3d69d722dc71b6d3a2",
+        "mips-unknown-linux-gnu": "b88bda2ab51fe8749ed5c68f76a2135c",
+        "mipsel-unknown-linux-gnu": "ec99e8fbeabf52bbc918aca90e3821de",
+        "powerpc-unknown-linux-gnu": "d80e1f04e4386525aa504d978ca87fd3",
+        "powerpc64-unknown-linux-gnu": "5741762256c0aee52feff980f690cf30",
+        "x86_64-unknown-linux-gnu": "ac9c973888cc5d85572f3a242d43fb98",
+    }
+    return get_hash(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "c55f8cf587d56ce7a4c64be3e75a8e84e5394e9c123572a4b4d3caca58990bff",
+        "arm-unknown-linux-gnueabi": "57acaaf25f66241cd8cf6ab2d71842007224a72d8fc8c139310a8cebc0af1a7a",
+        "arm-unknown-linux-gnueabihf": "a1ac0aaf111febcaf88f8a43117f1c87a2555526f81c777d53be99ca4623d3b1",
+        "armv7-unknown-linux-gnueabihf": "6273ca84d8bb497f4262c37e81f95bc521b82d823a723b5784dff88900185930",
+        "i686-unknown-linux-gnu": "a7ae8a2c068d507a76897cb4833a07438b8f04389e96965ab410b3d2b43c7c02",
+        "mips-unknown-linux-gnu": "0be94817bc17e83c34e087cf5e78e1fb23a109270707cc5798080dd7c3df3e7c",
+        "mipsel-unknown-linux-gnu": "249ec949d0fc2a758aaf503a362335c6876b9d093293d4f9bb86ab04330c6461",
+        "powerpc-unknown-linux-gnu": "8a6e0fefb0c23bb54e4a136f0630169bb7bcb50cda74fa5e6a494d2f8850b0c1",
+        "powerpc64-unknown-linux-gnu": "7af758ccb74d98d289d13c05ff8961076062c2da7aa8b61493a2535b968a7910",
+        "x86_64-unknown-linux-gnu": "87637e4f669d42ee7334a02f7f92ae81a9c41cc569e9e3354b0ca84ec251b78f",
+    }
+    return get_hash(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "6ab23a724f913d311db11db2e1e767f1",
+        "arm-unknown-linux-gnueabi": "4878bf45b650bf2fa97e7d5f48bc3b33",
+        "arm-unknown-linux-gnueabihf": "ae6fd69ec69fb166edd31997f012fd70",
+        "armv7-unknown-linux-gnueabihf": "2cc452384675f19549f97508cb02cbc8",
+        "i686-unknown-linux-gnu": "53fc14f02750f17391fa3925b8076473",
+        "x86_64-unknown-linux-gnu": "c66a083f0b8add2e85c50b5146c67a2b",
+    }
+    return get_hash(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "5b047438e96c6d3b17f0407af68420c0a5c28516ad6e8af77192d00813b1257c",
+        "arm-unknown-linux-gnueabi": "c32dbd2d7bba22e0a3fd7b12b4bbd43ad9006a5174e25b58b78061b762b29b58",
+        "arm-unknown-linux-gnueabihf": "ceadb2328b6308f027ce3aefb771ae441416bc7fc4d3bd35f08b490c783c37c8",
+        "armv7-unknown-linux-gnueabihf": "a53ecf28a5968ca6c8b472ac7f02efd51a85f6340ba5661f6047108cd4c4fe6e",
+        "i686-unknown-linux-gnu": "506bc2d49e5e71d143459a95b67d16b257c69a9c155219a87b80aa84732f4ddf",
+        "x86_64-unknown-linux-gnu": "abac14debf905a8beeffcbe6d168184de94fef3390f1d509890e32477a54cfad",
+    }
+    return get_hash(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
+
+include rust-bin.inc


### PR DESCRIPTION
These commits add support for rust 1.12.0 and automate the process of creating new recipes for a specific version of rust by grabbing artifacts and calculating the sha256/md5 checksums.  This should make adding future versions of rust to this layer very easy.

@nastevens