### PR TITLE
cargo: enable pkg-config when cross compiling

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -74,6 +74,7 @@ def build_type(d):
 
 cargo_do_compile() {
     export CC="${WRAPPER_DIR}/cc-wrapper.sh"
+    export PKG_CONFIG_ALLOW_CROSS="1"
     bbnote "which rustc:" `which rustc`
     bbnote "rustc --version" `rustc --version`
     bbnote "which cargo:" `which cargo`


### PR DESCRIPTION
The `pkgconfig` crate disables use of pkg-config lookup when
cross-compiling by default.  Within the context of Yocto we
want pkg-config to be used.  We can enable by setting the
`PKG_CONFIG_ALLOW_CROSS` flag.

CC @nastevens 