### PR TITLE
Rust 1.15.0

### DIFF
--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -185,6 +185,9 @@ EOF
 
 write_cargo_recipe() {
     cat <<EOF >>${CARGO_BIN_RECIPE}
+# Recipe for cargo $(cargo_version)
+# This corresponds to rust release ${TARGET_VERSION}
+
 def get_hash(hashes, triple):
     try:
         return hashes[triple]
@@ -225,7 +228,7 @@ EOF
 download_files
 
 RUST_BIN_RECIPE="${ROOT_DIR}/recipes-devtools/rust/rust-bin_${TARGET_VERSION}.bb"
-CARGO_BIN_RECIPE="${ROOT_DIR}/recipes-devtools/rust/cargo-bin_$(cargo_version).bb"
+CARGO_BIN_RECIPE="${ROOT_DIR}/recipes-devtools/rust/cargo-bin_${TARGET_VERSION}.bb"
 
 # create/clear files
 echo "" >${RUST_BIN_RECIPE}

--- a/recipes-devtools/rust/cargo-bin_1.11.0.bb
+++ b/recipes-devtools/rust/cargo-bin_1.11.0.bb
@@ -1,3 +1,7 @@
+
+# Recipe for cargo 20160705
+# This corresponds to rust release 1.11.0
+
 def get_hash(hashes, triple):
     try:
         return hashes[triple]
@@ -25,7 +29,6 @@ def cargo_sha256(triple):
         "x86_64-unknown-linux-gnu": "cf47787fd50bf6c7f68db290eab054e493e4619d42a8faf66565431449055f1c",
     }
     return get_hash(HASHES, triple)
-
 
 DEPENDS += "rust-bin (= 1.11.0)"
 LIC_FILES_CHKSUM = "\

--- a/recipes-devtools/rust/cargo-bin_1.12.0.bb
+++ b/recipes-devtools/rust/cargo-bin_1.12.0.bb
@@ -1,0 +1,39 @@
+
+# Recipe for cargo 20160821
+# This corresponds to rust release 1.12.0
+
+def get_hash(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "c146f696a277de6e9cc8599fa671564e",
+        "arm-unknown-linux-gnueabi": "5f522ca2ba1a8c2bf7f5708823d19b2e",
+        "arm-unknown-linux-gnueabihf": "1a62e360a6620643c88f43be09c530b5",
+        "armv7-unknown-linux-gnueabihf": "2bf99a05a400a63ec5b7dea99dbb9442",
+        "i686-unknown-linux-gnu": "6b1ecfcdf8f04c596a66e04b50319a92",
+        "x86_64-unknown-linux-gnu": "db8f4a71394eb2d02d9b467821847f93",
+    }
+    return get_hash(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "f7bb5adc3c2c252d0cca2bf998f3f34867ea15aa49a23d77de2014ce2da49df8",
+        "arm-unknown-linux-gnueabi": "4aed27a752d3023c85ea7cbb5d102239bc562a3a8e0635ba1eeed645f604c8f8",
+        "arm-unknown-linux-gnueabihf": "2d27879622433e819cee8c3a68fdb34edcac9d5469bd338e00e97594b0132d04",
+        "armv7-unknown-linux-gnueabihf": "abdf624436090239d27466ebd33c44245acf65337e510ed24c41567e02bace45",
+        "i686-unknown-linux-gnu": "46f22e9333f64d2aeff34be0a180b3a49b5a68e9f4a9cae8fe2814590f5a30a5",
+        "x86_64-unknown-linux-gnu": "bf91da07e7cf81c5ba2d0fc453cb21edbf0d26def4f1a28093bf10851cc017c0",
+    }
+    return get_hash(HASHES, triple)
+
+DEPENDS += "rust-bin (= 1.12.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
+    file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
+"
+
+include cargo-bin.inc

--- a/recipes-devtools/rust/cargo-bin_1.12.1.bb
+++ b/recipes-devtools/rust/cargo-bin_1.12.1.bb
@@ -1,4 +1,7 @@
 
+# Recipe for cargo 20160821
+# This corresponds to rust release 1.12.1
+
 def get_hash(hashes, triple):
     try:
         return hashes[triple]

--- a/recipes-devtools/rust/cargo-bin_1.14.0.bb
+++ b/recipes-devtools/rust/cargo-bin_1.14.0.bb
@@ -1,4 +1,7 @@
 
+# Recipe for cargo 298a0127f703d4c2500bb06d309488b92ef84ae1
+# This corresponds to rust release 1.14.0
+
 def get_hash(hashes, triple):
     try:
         return hashes[triple]

--- a/recipes-devtools/rust/cargo-bin_1.15.0.bb
+++ b/recipes-devtools/rust/cargo-bin_1.15.0.bb
@@ -1,0 +1,39 @@
+
+# Recipe for cargo 20170131
+# This corresponds to rust release 1.15.0
+
+def get_hash(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "5c8a3ef81ce68de05f1d893855e64ec1",
+        "arm-unknown-linux-gnueabi": "f724592cb147216a9605ef97f30464ad",
+        "arm-unknown-linux-gnueabihf": "c19ac3dac4e7ca852ec00f59da7c257f",
+        "armv7-unknown-linux-gnueabihf": "11655e07a9d92ffc0dfee49b5ee81ca3",
+        "i686-unknown-linux-gnu": "24d4eda62991bfbaecb3a6d1e09df143",
+        "x86_64-unknown-linux-gnu": "ad2b513d591f35271f1041e2e04f484c",
+    }
+    return get_hash(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "35fc6c708d1dcc7c44b4089aa8a9c0d3e82be31f30a550ef535e443d42e21d4b",
+        "arm-unknown-linux-gnueabi": "826c2a1ba88c9ed9d50e040f1936ffa3a005c12e34a348f563d8a016a9385a03",
+        "arm-unknown-linux-gnueabihf": "d8436690a182f536a348227fb8628fa964481aaa175e72c8f5df51f6149fb124",
+        "armv7-unknown-linux-gnueabihf": "34dbf0a411b22cb4ac9e935dfc15e713c087c2adb34ae530f1b380509225762e",
+        "i686-unknown-linux-gnu": "f20adfdcd6fb61c1252034e998998ec349c8a6b05c0320e47a539b0f6d1c76fa",
+        "x86_64-unknown-linux-gnu": "0655713cacab054e8e5a33e742081eebec8531a8c77d28a4294e6496123e8ab1",
+    }
+    return get_hash(HASHES, triple)
+
+DEPENDS += "rust-bin (= 1.15.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
+    file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
+"
+
+include cargo-bin.inc

--- a/recipes-devtools/rust/rust-bin_1.15.0.bb
+++ b/recipes-devtools/rust/rust-bin_1.15.0.bb
@@ -1,0 +1,61 @@
+
+def get_hash(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "9ac13d5c8a270f7e2f96cb2d2aeef9c2",
+        "arm-unknown-linux-gnueabi": "904014ac1b18d17680946d34081b64fe",
+        "arm-unknown-linux-gnueabihf": "edf26ff56cdd7661c68ce521f8be6ac3",
+        "armv7-unknown-linux-gnueabihf": "7c8fdcd7d2bdeca882e694727d2527f4",
+        "i686-unknown-linux-gnu": "06ccf27281ebe489cf569bdf65907a9c",
+        "mips-unknown-linux-gnu": "974c37c1e0b6b2b86aed676132e8c536",
+        "mipsel-unknown-linux-gnu": "dddc7b3592e5bbfd267675371753cdd1",
+        "powerpc-unknown-linux-gnu": "50575950b7f8ee37e5033dbb08639edd",
+        "x86_64-unknown-linux-gnu": "67ad9f1d85134dec59d0137fc317f3a6",
+    }
+    return get_hash(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "6ce986685791917030c6c811b211a518b6347fd3b36488523c0690769549cddf",
+        "arm-unknown-linux-gnueabi": "90ca71a666d2dc20e46a369e048a501909415bc1678105924a599815dc932d96",
+        "arm-unknown-linux-gnueabihf": "653ae98289bc3366dcaf57630b3ba1cfe356946e8ec2c45017592553dc01a702",
+        "armv7-unknown-linux-gnueabihf": "c0f18e11656df3ff5628f13bf9f0183b20910c48a182c06e7b1d1acc351eb893",
+        "i686-unknown-linux-gnu": "317ed31e4698dd7e35eb53a42bb159250044b5eb64b77b6005a5dfe419814241",
+        "mips-unknown-linux-gnu": "b0c1933781ea832436e6a6a6125fe856b790b91d783e976d8cd624f1674a13df",
+        "mipsel-unknown-linux-gnu": "a6e6fda7964b1b5d1c8ffd10d6f27c0092d7ad663e9fc6907e2bf4d84f4fdcdb",
+        "powerpc-unknown-linux-gnu": "24f0b49a7dfaec957dee990927e1186ab6aa35175048d71069431887fc847a0d",
+        "x86_64-unknown-linux-gnu": "a8349997993578c2ae730e0c84799d0c4df6f58a7e493c821a5be69e41ff3121",
+    }
+    return get_hash(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "5b54e3c7f8ae30ef731fa0dd751702f2",
+        "arm-unknown-linux-gnueabi": "6200e6d605f66f18edb0ddfac8830de0",
+        "arm-unknown-linux-gnueabihf": "0d4072cd58770fbe5d66797053e6582d",
+        "armv7-unknown-linux-gnueabihf": "5dadbc065ab1924cd44ddf1e68ab0a49",
+        "i686-unknown-linux-gnu": "92da88e57f048dcceb7ec380f2d909c5",
+        "x86_64-unknown-linux-gnu": "91190bcdc79d57a171e6c34f089f5985",
+    }
+    return get_hash(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "71bae9c1ac089db9eaf044ff5e806b09eb8306a8dd515d6358ac6e1a7b399496",
+        "arm-unknown-linux-gnueabi": "b3ead231a5776edc0fa35ba17e3e7af3f435f0c70ecb0196dccb3737ad02ff9b",
+        "arm-unknown-linux-gnueabihf": "af5517685de35c8c4bb0d735109244f777ee13939be449cbc10dc0521ca254dd",
+        "armv7-unknown-linux-gnueabihf": "fdf9aa96a3de582d82a388bf6770fb5f6eecff7a4ea590f2c7f05b88fdb516b8",
+        "i686-unknown-linux-gnu": "338dda1e2574cbf56c1f990a07a2520925f3c998b114d2b9952ae26dc65a3b9a",
+        "x86_64-unknown-linux-gnu": "0f7abbc790df9a02108673c0090c3127d3ee0053f3e1dbbe021b6da9c7d3f4da",
+    }
+    return get_hash(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
+
+include rust-bin.inc


### PR DESCRIPTION
Add rust 1.15.0 and update cargo versioning strategy to match rust release it was introduced with.