### PR TITLE
Fix two errors on latest yocto master

### DIFF
--- a/recipes-devtools/rust/cargo-bin.inc
+++ b/recipes-devtools/rust/cargo-bin.inc
@@ -30,3 +30,8 @@ python () {
 }
 
 BBCLASSEXTEND += "native nativesdk"
+
+FILES_${PN} += "/usr/lib/rustlib/manifest-cargo /usr/etc/bash_completion.d /usr/share/zsh/site-functions/_cargo"
+
+INSANE_SKIP_${PN} = "ldflags"
+INSANE_SKIP_${PN}-dev = "ldflags"


### PR DESCRIPTION
This fixes:

	ERROR: cargo-bin-20160821-r0 do_package: QA Issue: cargo-bin: Files/directories were installed but not shipped in any package:

and

	ERROR: cargo-bin-20160821-r0 do_package_qa: QA Issue: No GNU_HASH in the elf binary: '/mnt/src/poky/build/tmp/work/../packages-split/cargo-bin/usr/bin/cargo' [ldflags
]