### PR TITLE
Fix cargo download URLs and add recipes for rust 1.16.0

### DIFF
--- a/recipes-devtools/rust/cargo-bin.inc
+++ b/recipes-devtools/rust/cargo-bin.inc
@@ -18,12 +18,11 @@ do_install() {
 }
 
 python () {
-    base_uri = d.getVar("RUST_BASE_URI", True)
     pv = d.getVar("PV", True)
     pv_uri = pv[0:4] + '-' + pv[4:6] + '-' + pv[6:8]
     target = d.getVar("CARGO_HOST_TARGET", True)
-    cargo_uri = ("%s/cargo-dist/%s/cargo-nightly-%s.tar.gz;md5sum=%s;sha256sum=%s;downloadname=%s" %
-                 (base_uri, pv_uri, target, cargo_md5(target), cargo_sha256(target),
+    cargo_uri = ("%s;md5sum=%s;sha256sum=%s;downloadname=%s" %
+                 (cargo_url(target), cargo_md5(target), cargo_sha256(target),
                   d.getVar("PN", True) + "-" + pv + "-" + target + ".tar.gz"))
     src_uri = d.getVar("SRC_URI", True).split()
     d.setVar("SRC_URI", ' '.join(src_uri + [cargo_uri]))

--- a/recipes-devtools/rust/cargo-bin_1.11.0.bb
+++ b/recipes-devtools/rust/cargo-bin_1.11.0.bb
@@ -2,7 +2,7 @@
 # Recipe for cargo 20160705
 # This corresponds to rust release 1.11.0
 
-def get_hash(hashes, triple):
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
@@ -17,7 +17,7 @@ def cargo_md5(triple):
         "i686-unknown-linux-gnu": "a1f1e479289894639d6b9c58809560c8",
         "x86_64-unknown-linux-gnu": "8481e37267273bea60cf012d59156c80",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def cargo_sha256(triple):
     HASHES = {
@@ -28,7 +28,18 @@ def cargo_sha256(triple):
         "i686-unknown-linux-gnu": "f640d0dc0badeea87e2bab26b629e0acad5ebf1e7d8b6adef16febb72cab3da4",
         "x86_64-unknown-linux-gnu": "cf47787fd50bf6c7f68db290eab054e493e4619d42a8faf66565431449055f1c",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/cargo-dist/2016-07-05/cargo-nightly-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/cargo-dist/2016-07-05/cargo-nightly-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/cargo-dist/2016-07-05/cargo-nightly-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/cargo-dist/2016-07-05/cargo-nightly-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/cargo-dist/2016-07-05/cargo-nightly-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/cargo-dist/2016-07-05/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin (= 1.11.0)"
 LIC_FILES_CHKSUM = "\

--- a/recipes-devtools/rust/cargo-bin_1.12.0.bb
+++ b/recipes-devtools/rust/cargo-bin_1.12.0.bb
@@ -2,7 +2,7 @@
 # Recipe for cargo 20160821
 # This corresponds to rust release 1.12.0
 
-def get_hash(hashes, triple):
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
@@ -17,7 +17,7 @@ def cargo_md5(triple):
         "i686-unknown-linux-gnu": "6b1ecfcdf8f04c596a66e04b50319a92",
         "x86_64-unknown-linux-gnu": "db8f4a71394eb2d02d9b467821847f93",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def cargo_sha256(triple):
     HASHES = {
@@ -28,7 +28,18 @@ def cargo_sha256(triple):
         "i686-unknown-linux-gnu": "46f22e9333f64d2aeff34be0a180b3a49b5a68e9f4a9cae8fe2814590f5a30a5",
         "x86_64-unknown-linux-gnu": "bf91da07e7cf81c5ba2d0fc453cb21edbf0d26def4f1a28093bf10851cc017c0",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin (= 1.12.0)"
 LIC_FILES_CHKSUM = "\

--- a/recipes-devtools/rust/cargo-bin_1.12.1.bb
+++ b/recipes-devtools/rust/cargo-bin_1.12.1.bb
@@ -2,7 +2,7 @@
 # Recipe for cargo 20160821
 # This corresponds to rust release 1.12.1
 
-def get_hash(hashes, triple):
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
@@ -17,7 +17,7 @@ def cargo_md5(triple):
         "i686-unknown-linux-gnu": "6b1ecfcdf8f04c596a66e04b50319a92",
         "x86_64-unknown-linux-gnu": "db8f4a71394eb2d02d9b467821847f93",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def cargo_sha256(triple):
     HASHES = {
@@ -28,7 +28,18 @@ def cargo_sha256(triple):
         "i686-unknown-linux-gnu": "46f22e9333f64d2aeff34be0a180b3a49b5a68e9f4a9cae8fe2814590f5a30a5",
         "x86_64-unknown-linux-gnu": "bf91da07e7cf81c5ba2d0fc453cb21edbf0d26def4f1a28093bf10851cc017c0",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/cargo-dist/2016-08-21/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin (= 1.12.1)"
 LIC_FILES_CHKSUM = "\

--- a/recipes-devtools/rust/cargo-bin_1.14.0.bb
+++ b/recipes-devtools/rust/cargo-bin_1.14.0.bb
@@ -2,7 +2,7 @@
 # Recipe for cargo 298a0127f703d4c2500bb06d309488b92ef84ae1
 # This corresponds to rust release 1.14.0
 
-def get_hash(hashes, triple):
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
@@ -17,7 +17,7 @@ def cargo_md5(triple):
         "i686-unknown-linux-gnu": "aded776463929b457690423977ad4fa1",
         "x86_64-unknown-linux-gnu": "ad23654285541462e537b7187c2aaa75",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def cargo_sha256(triple):
     HASHES = {
@@ -28,7 +28,18 @@ def cargo_sha256(triple):
         "i686-unknown-linux-gnu": "03861ffd057032f201b723fa9018fbe18c5c8a76f0e9ad7fa52ee9bc2305d0d5",
         "x86_64-unknown-linux-gnu": "349a01c2c87f6b5c5cd39ddc6a86a2f6b009a05a48c95a633beea27ac22fed6b",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://s3.amazonaws.com/rust-lang-ci/cargo-builds/298a0127f703d4c2500bb06d309488b92ef84ae1/cargo-nightly-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://s3.amazonaws.com/rust-lang-ci/cargo-builds/298a0127f703d4c2500bb06d309488b92ef84ae1/cargo-nightly-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://s3.amazonaws.com/rust-lang-ci/cargo-builds/298a0127f703d4c2500bb06d309488b92ef84ae1/cargo-nightly-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://s3.amazonaws.com/rust-lang-ci/cargo-builds/298a0127f703d4c2500bb06d309488b92ef84ae1/cargo-nightly-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://s3.amazonaws.com/rust-lang-ci/cargo-builds/298a0127f703d4c2500bb06d309488b92ef84ae1/cargo-nightly-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://s3.amazonaws.com/rust-lang-ci/cargo-builds/298a0127f703d4c2500bb06d309488b92ef84ae1/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin (= 1.14.0)"
 LIC_FILES_CHKSUM = "\

--- a/recipes-devtools/rust/cargo-bin_1.15.0.bb
+++ b/recipes-devtools/rust/cargo-bin_1.15.0.bb
@@ -2,7 +2,7 @@
 # Recipe for cargo 20170131
 # This corresponds to rust release 1.15.0
 
-def get_hash(hashes, triple):
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
@@ -17,7 +17,7 @@ def cargo_md5(triple):
         "i686-unknown-linux-gnu": "24d4eda62991bfbaecb3a6d1e09df143",
         "x86_64-unknown-linux-gnu": "ad2b513d591f35271f1041e2e04f484c",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def cargo_sha256(triple):
     HASHES = {
@@ -28,7 +28,18 @@ def cargo_sha256(triple):
         "i686-unknown-linux-gnu": "f20adfdcd6fb61c1252034e998998ec349c8a6b05c0320e47a539b0f6d1c76fa",
         "x86_64-unknown-linux-gnu": "0655713cacab054e8e5a33e742081eebec8531a8c77d28a4294e6496123e8ab1",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-01-31/cargo-0.16.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2017-01-31/cargo-0.16.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2017-01-31/cargo-0.16.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2017-01-31/cargo-0.16.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-01-31/cargo-0.16.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-01-31/cargo-0.16.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin (= 1.15.0)"
 LIC_FILES_CHKSUM = "\

--- a/recipes-devtools/rust/cargo-bin_1.15.1.bb
+++ b/recipes-devtools/rust/cargo-bin_1.15.1.bb
@@ -2,7 +2,7 @@
 # Recipe for cargo 20170209
 # This corresponds to rust release 1.15.1
 
-def get_hash(hashes, triple):
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
@@ -17,7 +17,7 @@ def cargo_md5(triple):
         "i686-unknown-linux-gnu": "24d4eda62991bfbaecb3a6d1e09df143",
         "x86_64-unknown-linux-gnu": "ad2b513d591f35271f1041e2e04f484c",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def cargo_sha256(triple):
     HASHES = {
@@ -28,7 +28,18 @@ def cargo_sha256(triple):
         "i686-unknown-linux-gnu": "f20adfdcd6fb61c1252034e998998ec349c8a6b05c0320e47a539b0f6d1c76fa",
         "x86_64-unknown-linux-gnu": "0655713cacab054e8e5a33e742081eebec8531a8c77d28a4294e6496123e8ab1",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-02-09/cargo-0.16.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2017-02-09/cargo-0.16.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2017-02-09/cargo-0.16.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2017-02-09/cargo-0.16.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-02-09/cargo-0.16.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-02-09/cargo-0.16.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin (= 1.15.1)"
 LIC_FILES_CHKSUM = "\

--- a/recipes-devtools/rust/cargo-bin_1.16.0.bb
+++ b/recipes-devtools/rust/cargo-bin_1.16.0.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20170311
+# This corresponds to rust release 1.16.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "d34352bf18875df84d47e2e4a5fa52ff",
+        "arm-unknown-linux-gnueabi": "d1da2bcce20d8ae452835be10300c0ab",
+        "arm-unknown-linux-gnueabihf": "f91c8ad235968bd7b9816bcf46560d22",
+        "armv7-unknown-linux-gnueabihf": "cf2f9382fbb9b4a4dad0afc76d90f5aa",
+        "i686-unknown-linux-gnu": "ff761a210ccd74ee2c7f8467994c0bfa",
+        "x86_64-unknown-linux-gnu": "b7c8df22546d317e0de8e38440e23f2a",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "a73fe409f3d206454101e91a27f4830cf8fea4e65bb642e8d0973822cb0eb11e",
+        "arm-unknown-linux-gnueabi": "07f31188173a8a06fd18296c06bb5665117faff4dc6748c6f672f71e1e692d7f",
+        "arm-unknown-linux-gnueabihf": "3adebf177ab71445603a98169650d25cfa9ee716cdc49e39a4534b0c7e50bcc0",
+        "armv7-unknown-linux-gnueabihf": "6a522088d3f71e9044d0ac1a6ae3191912184ba9cd1f9493ccd788d0e2e687e4",
+        "i686-unknown-linux-gnu": "cc1d0573341a892e80cb273b9dd0cc9b0703cb5b046b389cc52252095965af60",
+        "x86_64-unknown-linux-gnu": "dcbf1c0f57414501b3d2c6b26cfa7fdfc951c72862e4e3e1e290ab4761961747",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-03-11/cargo-0.17.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2017-03-11/cargo-0.17.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2017-03-11/cargo-0.17.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2017-03-11/cargo-0.17.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-03-11/cargo-0.17.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-03-11/cargo-0.17.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin (= 1.16.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
+    file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
+"
+
+include cargo-bin.inc

--- a/recipes-devtools/rust/rust-bin_1.11.0.bb
+++ b/recipes-devtools/rust/rust-bin_1.11.0.bb
@@ -1,8 +1,10 @@
-def get_hash(hashes, triple):
+
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
         bb.fatal("Unsupported triple: %s" % triple)
+
 
 def rust_std_md5(triple):
     HASHES = {
@@ -14,11 +16,9 @@ def rust_std_md5(triple):
         "mips-unknown-linux-gnu": "b90ae32b2681b07301d011ce17067376",
         "mipsel-unknown-linux-gnu": "d68a0b100c1d7e84397b92fcdd5a0c08",
         "powerpc-unknown-linux-gnu": "fabcfe72cba56da32696f08fea3cde4b",
-        "powerpc64-unknown-linux-gnu": "14ce3a15f88250896c452058aa483dae",
-        "powerpc64le-unknown-linux-gnu": "ef8ef16204bd8229f93ddb2dd6e2c1b4",
         "x86_64-unknown-linux-gnu": "04497872d0ed1eb7efa8fefcfce71ab4",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rust_std_sha256(triple):
     HASHES = {
@@ -30,11 +30,9 @@ def rust_std_sha256(triple):
         "mips-unknown-linux-gnu": "830667f2dfbbc6c5ed1c7ca9adfb6687e00e49ae085b22d63a9d1a55329cae8d",
         "mipsel-unknown-linux-gnu": "57be30f7bb793ec82de5f1b6a823d04e61dcdf18a4e7bd045c1333196448f987",
         "powerpc-unknown-linux-gnu": "c044c8b1483e774f2fc13c98e961143ec3bc0a7ade0ae0fd25827b3eeba97979",
-        "powerpc64-unknown-linux-gnu": "cdc592d78eac54fd3e9868627a6f506d114147124d7ee54c4a1fa6d021d336b0",
-        "powerpc64le-unknown-linux-gnu": "1edc3225047e09c7a720d4629c919dd29a08461305418314288c4cd693902456",
         "x86_64-unknown-linux-gnu": "893a53b5f78ec9eb7ac4ad3b3bd375d2ddad8ca1687ed5867621ec157eddbea5",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_md5(triple):
     HASHES = {
@@ -45,7 +43,7 @@ def rustc_md5(triple):
         "i686-unknown-linux-gnu": "932c698c242238a68530c2c15fd0b810",
         "x86_64-unknown-linux-gnu": "b83d7a1a90c2d80bef97a518022948c8",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_sha256(triple):
     HASHES = {
@@ -56,8 +54,7 @@ def rustc_sha256(triple):
         "i686-unknown-linux-gnu": "16273afc0540b4353e54faab6b73e16310ae724f3dc941938bf09129b08bed03",
         "x86_64-unknown-linux-gnu": "e9d27a72900da33c1bbd0e59dd42fd6414c6bcdfa33593fb7c7360068406394a",
     }
-    return get_hash(HASHES, triple)
-
+    return get_by_triple(HASHES, triple)
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 

--- a/recipes-devtools/rust/rust-bin_1.12.0.bb
+++ b/recipes-devtools/rust/rust-bin_1.12.0.bb
@@ -1,5 +1,5 @@
 
-def get_hash(hashes, triple):
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
@@ -16,10 +16,9 @@ def rust_std_md5(triple):
         "mips-unknown-linux-gnu": "b88bda2ab51fe8749ed5c68f76a2135c",
         "mipsel-unknown-linux-gnu": "ec99e8fbeabf52bbc918aca90e3821de",
         "powerpc-unknown-linux-gnu": "d80e1f04e4386525aa504d978ca87fd3",
-        "powerpc64-unknown-linux-gnu": "5741762256c0aee52feff980f690cf30",
         "x86_64-unknown-linux-gnu": "ac9c973888cc5d85572f3a242d43fb98",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rust_std_sha256(triple):
     HASHES = {
@@ -31,10 +30,9 @@ def rust_std_sha256(triple):
         "mips-unknown-linux-gnu": "0be94817bc17e83c34e087cf5e78e1fb23a109270707cc5798080dd7c3df3e7c",
         "mipsel-unknown-linux-gnu": "249ec949d0fc2a758aaf503a362335c6876b9d093293d4f9bb86ab04330c6461",
         "powerpc-unknown-linux-gnu": "8a6e0fefb0c23bb54e4a136f0630169bb7bcb50cda74fa5e6a494d2f8850b0c1",
-        "powerpc64-unknown-linux-gnu": "7af758ccb74d98d289d13c05ff8961076062c2da7aa8b61493a2535b968a7910",
         "x86_64-unknown-linux-gnu": "87637e4f669d42ee7334a02f7f92ae81a9c41cc569e9e3354b0ca84ec251b78f",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_md5(triple):
     HASHES = {
@@ -45,7 +43,7 @@ def rustc_md5(triple):
         "i686-unknown-linux-gnu": "53fc14f02750f17391fa3925b8076473",
         "x86_64-unknown-linux-gnu": "c66a083f0b8add2e85c50b5146c67a2b",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_sha256(triple):
     HASHES = {
@@ -56,7 +54,7 @@ def rustc_sha256(triple):
         "i686-unknown-linux-gnu": "506bc2d49e5e71d143459a95b67d16b257c69a9c155219a87b80aa84732f4ddf",
         "x86_64-unknown-linux-gnu": "abac14debf905a8beeffcbe6d168184de94fef3390f1d509890e32477a54cfad",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 

--- a/recipes-devtools/rust/rust-bin_1.12.1.bb
+++ b/recipes-devtools/rust/rust-bin_1.12.1.bb
@@ -1,5 +1,5 @@
 
-def get_hash(hashes, triple):
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
@@ -18,7 +18,7 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "e8a89a177ceb7351e8467f91b060939e",
         "x86_64-unknown-linux-gnu": "200283f7ac053dedd12216478a62e101",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rust_std_sha256(triple):
     HASHES = {
@@ -32,7 +32,7 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "3e018f2f71e24c0b82a2e737d712eaee4e0e1e9525e9518f855851ddcf362ce9",
         "x86_64-unknown-linux-gnu": "2d428042fd0b6cc1b08584341b2ad81dabe7abdfadcb0eb5082cfbc93e1ab90b",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_md5(triple):
     HASHES = {
@@ -43,7 +43,7 @@ def rustc_md5(triple):
         "i686-unknown-linux-gnu": "f1c1b3c6cd6195e4fbc386a7ab49e64d",
         "x86_64-unknown-linux-gnu": "a03bdb0111e3b68a3626237d2ec7cb95",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_sha256(triple):
     HASHES = {
@@ -54,7 +54,7 @@ def rustc_sha256(triple):
         "i686-unknown-linux-gnu": "6c1f62db6f9c317aa656774b5193ce3d0783de4c73f2424d98ff4c9f1f962d25",
         "x86_64-unknown-linux-gnu": "a753e3b6cfa8417978e4bfc0d3282f22be4abc5e106af39f4cb54dc775f64546",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 

--- a/recipes-devtools/rust/rust-bin_1.14.0.bb
+++ b/recipes-devtools/rust/rust-bin_1.14.0.bb
@@ -1,5 +1,5 @@
 
-def get_hash(hashes, triple):
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
@@ -18,7 +18,7 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "ebb4c13b5010457f91e591ae5dfbf7c4",
         "x86_64-unknown-linux-gnu": "518e492fc3d50d8c678056eb788bd0e7",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rust_std_sha256(triple):
     HASHES = {
@@ -32,7 +32,7 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "c8985bfb8bae69e72c5a6f0538b2990ebf224011d4a2e31cd4513dd16e5263ed",
         "x86_64-unknown-linux-gnu": "3a609bfe9572c742d71199faad578ee76abe9067cd8df698bda6e3ef5caf6ec4",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_md5(triple):
     HASHES = {
@@ -43,7 +43,7 @@ def rustc_md5(triple):
         "i686-unknown-linux-gnu": "aa62d4b70cfaf785ff7b1c72cb94b9a2",
         "x86_64-unknown-linux-gnu": "f178d9d6aad0f87c451f4b2f93170633",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_sha256(triple):
     HASHES = {
@@ -54,7 +54,7 @@ def rustc_sha256(triple):
         "i686-unknown-linux-gnu": "52b7df5025c302d82f0572fbdc74309334bad36e796c4a2fdf934abe2e5e23ac",
         "x86_64-unknown-linux-gnu": "0eeec4211aa872f24c220200a0c2b095bbfc9c0f737c1c5df2555967c8f36787",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 

--- a/recipes-devtools/rust/rust-bin_1.15.0.bb
+++ b/recipes-devtools/rust/rust-bin_1.15.0.bb
@@ -1,5 +1,5 @@
 
-def get_hash(hashes, triple):
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
@@ -18,7 +18,7 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "50575950b7f8ee37e5033dbb08639edd",
         "x86_64-unknown-linux-gnu": "67ad9f1d85134dec59d0137fc317f3a6",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rust_std_sha256(triple):
     HASHES = {
@@ -32,7 +32,7 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "24f0b49a7dfaec957dee990927e1186ab6aa35175048d71069431887fc847a0d",
         "x86_64-unknown-linux-gnu": "a8349997993578c2ae730e0c84799d0c4df6f58a7e493c821a5be69e41ff3121",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_md5(triple):
     HASHES = {
@@ -43,7 +43,7 @@ def rustc_md5(triple):
         "i686-unknown-linux-gnu": "92da88e57f048dcceb7ec380f2d909c5",
         "x86_64-unknown-linux-gnu": "91190bcdc79d57a171e6c34f089f5985",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_sha256(triple):
     HASHES = {
@@ -54,7 +54,7 @@ def rustc_sha256(triple):
         "i686-unknown-linux-gnu": "338dda1e2574cbf56c1f990a07a2520925f3c998b114d2b9952ae26dc65a3b9a",
         "x86_64-unknown-linux-gnu": "0f7abbc790df9a02108673c0090c3127d3ee0053f3e1dbbe021b6da9c7d3f4da",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 

--- a/recipes-devtools/rust/rust-bin_1.15.1.bb
+++ b/recipes-devtools/rust/rust-bin_1.15.1.bb
@@ -1,5 +1,5 @@
 
-def get_hash(hashes, triple):
+def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
@@ -18,7 +18,7 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "372fe044ec52e79bb0b95418b719fa85",
         "x86_64-unknown-linux-gnu": "da2469eacf2a079563d6d7e6f5319efa",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rust_std_sha256(triple):
     HASHES = {
@@ -32,7 +32,7 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "399064c741871e0cbd56ca2feec09cc96f53610303761a6059b836d35151698c",
         "x86_64-unknown-linux-gnu": "69b251b478e284dfcaefc1153183f26f41d504ae213a81224f2101d8dbd52bb0",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_md5(triple):
     HASHES = {
@@ -43,7 +43,7 @@ def rustc_md5(triple):
         "i686-unknown-linux-gnu": "523c90836120f3388d7c7a1eaa4df6ab",
         "x86_64-unknown-linux-gnu": "6d01f429917fa6b7053054e6b5cba138",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 def rustc_sha256(triple):
     HASHES = {
@@ -54,7 +54,7 @@ def rustc_sha256(triple):
         "i686-unknown-linux-gnu": "a833304f99071600c72ecd868c1c7bd5ce49d1102332637a8eb7adb942f349ab",
         "x86_64-unknown-linux-gnu": "33ff44672b731fc71145974ce84194a1a9bafe6da3a74fd1e7543f12467f8894",
     }
-    return get_hash(HASHES, triple)
+    return get_by_triple(HASHES, triple)
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 

--- a/recipes-devtools/rust/rust-bin_1.16.0.bb
+++ b/recipes-devtools/rust/rust-bin_1.16.0.bb
@@ -1,0 +1,61 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "2ccc7a28cd2215479cd69ee46bb8316c",
+        "arm-unknown-linux-gnueabi": "5869e3c8b3d1382ea6f00ec8413d608d",
+        "arm-unknown-linux-gnueabihf": "257defe4dc2175965eccae2dd9e40f06",
+        "armv7-unknown-linux-gnueabihf": "24c11f7ce6009fb558e76baf20421b55",
+        "i686-unknown-linux-gnu": "2944870b1626d1c059718c1c461a946f",
+        "mips-unknown-linux-gnu": "af64121d2c89c88530e1f0873dd81dc9",
+        "mipsel-unknown-linux-gnu": "3405d5df0f8ff59e84d93c67f190e57d",
+        "powerpc-unknown-linux-gnu": "fcc7896e902fdf519046f695ded0f1e9",
+        "x86_64-unknown-linux-gnu": "033c36a8dccd54f5e417dbd137cca1be",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "dafe92282dd5ca67f95c5b8cc2a729b2f8cb04d6e30c6d790819a27f0119d8ca",
+        "arm-unknown-linux-gnueabi": "b220d8c0fd1a5039b91181fd083e96c9b48c71fb5892e98ec99e60e4ac4bb29d",
+        "arm-unknown-linux-gnueabihf": "bc7846a432d672995bf7ef349a79ee422a003b808579996fe0a30f335dce16f4",
+        "armv7-unknown-linux-gnueabihf": "dd6869bf2d2f31711d327ac9a5e42667a65b3fa9476e36a4c6418cb1cc5109fb",
+        "i686-unknown-linux-gnu": "5a74e3661f4b300bf73353389acab097f3e07813b0f3073007830a549656054a",
+        "mips-unknown-linux-gnu": "0d2f91ce61e261e11f44732ea3bdf04c2dd498f441b89b3ab1cf0eebc6d0b8cb",
+        "mipsel-unknown-linux-gnu": "deeade93a16fa3c2258fb11ca2cbc31fa22e721c89f5db7457ac233351efe073",
+        "powerpc-unknown-linux-gnu": "a8faf140202c3ad35fd335b32c4b0ce14aad0ef5b9485b9a542b1bb8aa495a7a",
+        "x86_64-unknown-linux-gnu": "cbd43de2ab819d3332ce309046f3b5d715c1b47877a237791b99c96b1fe0d555",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "d237f012426c38e6ffe0705711f8dcf5",
+        "arm-unknown-linux-gnueabi": "96ce680f007c5196a9be563a00723115",
+        "arm-unknown-linux-gnueabihf": "69fb063d3fd974bcd64980a2f26aa239",
+        "armv7-unknown-linux-gnueabihf": "76eaa614bee2d8fd4233942337869c85",
+        "i686-unknown-linux-gnu": "9059260e519f602f73148097670984a6",
+        "x86_64-unknown-linux-gnu": "b4a4b5b48c0e23b7c87687b60254df45",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "4ef8377e0a118d3a90b16b0c925719bdda521aa9392c64e4b65a272d26fae50a",
+        "arm-unknown-linux-gnueabi": "e4e8d9f06204709899bcd25a9d1b8cf5d6ec014409cd0c24f98e10351540e3d0",
+        "arm-unknown-linux-gnueabihf": "8ea4188d46e44588e30d51d296666d1609429365437ff44f6d8b3b6a058b1827",
+        "armv7-unknown-linux-gnueabihf": "9f90916ba8b2e1abad66843bfcd2881ff928d530eaf2dc5249a0865e97209f6c",
+        "i686-unknown-linux-gnu": "f8e0f96c17d8345be7818035e9bcae8e809a1b13635fe9a322df4a82d6dd1275",
+        "x86_64-unknown-linux-gnu": "b1dc3f754eeaf03891a3bd398c8c5024404c0078a334e5d8795e9dc419d147b3",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
+
+include rust-bin.inc


### PR DESCRIPTION
Since at least version 1.15.1 and possibly before the download
URL for cargo was not being constructed correctly. Now the URL
is grabbed directly from the `channel-rust-<version>.toml`. All
of the existing recipes were regenerated with the updated
`build-new-version.sh` script.