### PR TITLE
rustup: add support for rustc 1.21.0

### DIFF
--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -177,7 +177,7 @@ EOF
 
 write_final_contents() {
     cat <<EOF >>${RUST_BIN_RECIPE}
-LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c709a09d1b062d9a908e3631c1e1cdf5"
 
 include rust-bin.inc
 EOF
@@ -229,7 +229,7 @@ EOF
 DEPENDS += "rust-bin (= ${TARGET_VERSION})"
 LIC_FILES_CHKSUM = "\\
     file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \\
-    file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \\
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \\
 "
 
 include cargo-bin.inc

--- a/recipes-devtools/rust/cargo-bin.inc
+++ b/recipes-devtools/rust/cargo-bin.inc
@@ -7,8 +7,6 @@ inherit rust-common
 
 CARGO_HOST_TARGET = "${@rust_target(d, 'HOST')}"
 
-S = "${WORKDIR}/cargo-nightly-${CARGO_HOST_TARGET}"
-
 do_install() {
     ${S}/install.sh --destdir="${D}" --prefix="${prefix}"
     rm -f ${D}${prefix}/lib/rustlib/uninstall.sh
@@ -26,6 +24,7 @@ python () {
                   d.getVar("PN", True) + "-" + pv + "-" + target + ".tar.gz"))
     src_uri = d.getVar("SRC_URI", True).split()
     d.setVar("SRC_URI", ' '.join(src_uri + [cargo_uri]))
+    d.setVar("S", "{}/{}".format(d.getVar("WORKDIR", True), cargo_url(target).split('/')[-1].replace('.tar.gz', '')))
 }
 
 BBCLASSEXTEND += "native nativesdk"

--- a/recipes-devtools/rust/cargo-bin_1.21.0.bb
+++ b/recipes-devtools/rust/cargo-bin_1.21.0.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20171012
+# This corresponds to rust release 1.21.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "082fad37a09b824be4265aa9982f1e44",
+        "arm-unknown-linux-gnueabi": "b481b8d8cc29d5ceeda6be2acad1cce5",
+        "arm-unknown-linux-gnueabihf": "a7f9c40d88e8a849c68b946eabd44fb2",
+        "armv7-unknown-linux-gnueabihf": "cb6fca7b274fec7388a1f90d88ddd375",
+        "i686-unknown-linux-gnu": "5d9f7b60e2e2b7c1aa29d84ea7ebb64d",
+        "x86_64-unknown-linux-gnu": "b870d85feb8958727dbdad476007d65c",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "440b6f3b9f7be895f2bffe5e314c98af41421c2b9cb1cfd19760e896b18eef87",
+        "arm-unknown-linux-gnueabi": "32e90fdedb99f32f502d54aefe68040e19ce7771a3ef6648a5d115af7b704bda",
+        "arm-unknown-linux-gnueabihf": "79b5c64d05c9fb0a1dd89d75e3b68726e25c52222ba901528d75f6ef50edbefc",
+        "armv7-unknown-linux-gnueabihf": "54f09a39a74905ab9bb89dae898479713360dfb2ee126cb592dff517ea06b7f3",
+        "i686-unknown-linux-gnu": "158ea19c2c72a168de2a71a2b2fda7435080d238439f4460a7bb4a082f109443",
+        "x86_64-unknown-linux-gnu": "eca53c055006f3a77871317368d4bd585ffb04ddbf0ecd2aa79aaf5cc4c84280",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-10-12/cargo-0.22.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2017-10-12/cargo-0.22.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2017-10-12/cargo-0.22.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2017-10-12/cargo-0.22.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-10-12/cargo-0.22.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2017-10-12/cargo-0.22.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin (= 1.21.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+include cargo-bin.inc

--- a/recipes-devtools/rust/rust-bin_1.21.0.bb
+++ b/recipes-devtools/rust/rust-bin_1.21.0.bb
@@ -1,0 +1,61 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "ead3bd18db5a6f49af0001f3ac2f930b",
+        "arm-unknown-linux-gnueabi": "e55cf673cb5dc76c099fd4a80377bc77",
+        "arm-unknown-linux-gnueabihf": "c641f936b5ab8bff78706e88e97c7e82",
+        "armv7-unknown-linux-gnueabihf": "ab2492315e8d32df702679c09b0b48e9",
+        "i686-unknown-linux-gnu": "d97d2b6720c9a06ac369668d9c2f496f",
+        "mips-unknown-linux-gnu": "571a206d47a410c0c8fb71a3a6b68f47",
+        "mipsel-unknown-linux-gnu": "3b5d02e8dd9b1ac1a77fd17519b3c43b",
+        "powerpc-unknown-linux-gnu": "21a5fe2a20b604e34981cc4cf4e0479a",
+        "x86_64-unknown-linux-gnu": "b6e348e588a789eca369b5404e7d7656",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "e1e0276d8be49b58b226fdca19f56fc3ea8d7e2a64b81acca30d87dd9f3fec96",
+        "arm-unknown-linux-gnueabi": "604832eccc03b401b501aeaca152b486568d7c9fcb55242619b0156de1d1143b",
+        "arm-unknown-linux-gnueabihf": "9ac6021d3ddbab5bbf9e33cc6d1a3f9101a6ca93c85ddd7be9cab6e76e75b5ac",
+        "armv7-unknown-linux-gnueabihf": "65a730c78486a8da119fb5853150eb23f4392cf6b8c197916f71d61c00dfa1fc",
+        "i686-unknown-linux-gnu": "372aa5a123216dcca204caa9bd909c2db711554ac37f9a8d7222c190767223e3",
+        "mips-unknown-linux-gnu": "02a083136f6ac88dc81e48693de89934e18cdc15c181a42ddcf7762d9f919fca",
+        "mipsel-unknown-linux-gnu": "255034f25203a66848a9b25da4f12362fff1d851fe868364b3759d72ead8f839",
+        "powerpc-unknown-linux-gnu": "ca7f0e0b9cd49cb6377460f4234be0cce2a2dceb5ce71449f5ce2996c5abb693",
+        "x86_64-unknown-linux-gnu": "4c431863a6a03b24b69c539de92fbdaec916e2b70df89cb788ac1e09b2e0b70a",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "986634bc08437ff5d760ef747dc9b627",
+        "arm-unknown-linux-gnueabi": "b017d543b9ec539d7df7383c97cc6522",
+        "arm-unknown-linux-gnueabihf": "08467bb0eb7d12fc6bc78ef84722377e",
+        "armv7-unknown-linux-gnueabihf": "b6fb1cf2ec6f4e80234ab6716804f0e8",
+        "i686-unknown-linux-gnu": "c3d3d0147c720c51b0bf54d7984e4fa7",
+        "x86_64-unknown-linux-gnu": "6b5b084cb997d20d11b7b2b566ffccdd",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "2fe9a90d5163a02a35693fa48ce1e56f76f39e953911ca5d0d8cdc491a1df4ab",
+        "arm-unknown-linux-gnueabi": "08d34686bd4e1ae17d5272f82b78763dfa5bd56f61cdbfaf557ef57b1b3e7713",
+        "arm-unknown-linux-gnueabihf": "1c7f380110d42fe3158c7c74dd3db4e54023577537dc60b92a2b49dbfc09f4be",
+        "armv7-unknown-linux-gnueabihf": "b61b1380b2711a731dcc89e43d95be265e0715721168f2a6055f6cc392a77b9c",
+        "i686-unknown-linux-gnu": "706744c8f8373b4214650e790229e5bd410f8e1107680865ef25e29f1c7e5466",
+        "x86_64-unknown-linux-gnu": "47dad29c64cd60fb2e3e5a723c191c99dae883bf8e723dd0e6631427f148b87f",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c709a09d1b062d9a908e3631c1e1cdf5"
+
+include rust-bin.inc


### PR DESCRIPTION
There were a few changes upstream that required changes to core
recipes.  I believe this doesn't break the older versions although
you will no longer be able to use the same script to regenerate
older rust versions (which should be fine).

CC @tpmanley