### PR TITLE
Enable debug symbols when building --release

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -46,6 +46,9 @@ linker = "${WRAPPER_DIR}/cc-wrapper.sh"
 
 [build]
 rustflags = ["-C", "rpath"]
+
+[profile.release]
+debug = true
 EOF
 }
 


### PR DESCRIPTION
Enable debug symbols in release mode. Note that this doesn't add any additional overhead since the debug symbols will be stripped to a `-dbg` package either way.