### PR TITLE
Fix yocto misunderstandings

### DIFF
--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -179,7 +179,7 @@ write_final_contents() {
     cat <<EOF >>${RUST_BIN_RECIPE}
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c709a09d1b062d9a908e3631c1e1cdf5"
 
-include rust-bin.inc
+require rust-bin-cross.inc
 EOF
 }
 
@@ -226,26 +226,26 @@ EOF
     }
     return get_by_triple(URLS, triple)
 
-DEPENDS += "rust-bin (= ${TARGET_VERSION})"
+DEPENDS += "rust-bin-cross-\${TARGET_ARCH} (= ${TARGET_VERSION})"
 LIC_FILES_CHKSUM = "\\
     file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \\
     file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \\
 "
 
-include cargo-bin.inc
+require cargo-bin-cross.inc
 EOF
 }
 
 download_files
 
-RUST_BIN_RECIPE="${ROOT_DIR}/recipes-devtools/rust/rust-bin_${TARGET_VERSION}.bb"
-CARGO_BIN_RECIPE="${ROOT_DIR}/recipes-devtools/rust/cargo-bin_${TARGET_VERSION}.bb"
+RUST_BIN_RECIPE="${ROOT_DIR}/recipes-devtools/rust/rust-bin-cross_${TARGET_VERSION}.bb"
+CARGO_BIN_RECIPE="${ROOT_DIR}/recipes-devtools/rust/cargo-bin-cross_${TARGET_VERSION}.bb"
 
 # create/clear files
 echo "" >${RUST_BIN_RECIPE}
 echo "" >${CARGO_BIN_RECIPE}
 
-# write the rust-bin recipe
+# write the rust recipe
 write_get_by_triple
 write_std_md5
 write_std_sha256

--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -1,24 +1,18 @@
 inherit rust-common
 
+DEPENDS += "cargo-bin-cross-${TARGET_ARCH}"
+
 # Move CARGO_HOME from default of ~/.cargo
 export CARGO_HOME = "${WORKDIR}/cargo_home"
 
 # If something fails while building, this might give useful information
 export RUST_BACKTRACE = "1"
 
-DEPENDS += "\
-    rust-bin \
-    cargo-bin-native \
-"
-
 # Do build out-of-tree
 B = "${WORKDIR}/target"
 export CARGO_TARGET_DIR = "${B}"
 
-# When cross-compiling, explicitly set target. When natively compiling target
-# the BUILD system.
 RUST_TARGET = "${@rust_target(d, 'TARGET')}"
-RUST_TARGET_class-native = "${@rust_target(d, 'BUILD')}"
 RUST_BUILD = "${@rust_target(d, 'BUILD')}"
 
 # Additional flags passed directly to the "cargo build" invocation
@@ -132,5 +126,4 @@ cargo_do_install() {
     fi
 }
 
-BBCLASSEXTEND += "native nativesdk"
 EXPORT_FUNCTIONS do_configure do_compile do_install

--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -21,6 +21,9 @@ EXTRA_CARGO_FLAGS ??= ""
 # Space-separated list of features to enable
 CARGO_FEATURES ??= ""
 
+# Control the Cargo build type (debug or release)
+CARGO_BUILD_TYPE ?= "--release"
+
 CARGO_DEBUG_DIR = "${B}/${RUST_TARGET}/debug"
 CARGO_RELEASE_DIR = "${B}/${RUST_TARGET}/release"
 WRAPPER_DIR = "${WORKDIR}/wrappers"
@@ -29,7 +32,7 @@ CARGO_BUILD_FLAGS = "\
     --verbose \
     --manifest-path ${S}/Cargo.toml \
     --target=${RUST_TARGET} \
-    --${@build_type(d)} \
+    ${CARGO_BUILD_TYPE} \
     ${@base_conditional('CARGO_FEATURES', '', '', '--features "${CARGO_FEATURES}"', d)} \
     ${EXTRA_CARGO_FLAGS} \
 "
@@ -78,13 +81,6 @@ cargo_do_configure() {
     create_cargo_config
 }
 
-def build_type(d):
-    is_debug_build = d.getVar("PN", True).endswith("-dbg")
-    if is_debug_build:
-        return "debug"
-    else:
-        return "release"
-
 cargo_do_compile() {
     export TARGET_CC="${WRAPPER_DIR}/cc-wrapper.sh"
     export CC="${WRAPPER_DIR}/cc-native-wrapper.sh"
@@ -102,10 +98,10 @@ cargo_do_compile() {
 
 cargo_do_install() {
     install -d "${D}${bindir}"
-    if [ "${@build_type}" = "debug" ]; then
-        local cargo_bindir="${CARGO_DEBUG_DIR}"
-    else
+    if [ "${CARGO_BUILD_TYPE}" = "--release" ]; then
         local cargo_bindir="${CARGO_RELEASE_DIR}"
+    else
+        local cargo_bindir="${CARGO_DEBUG_DIR}"
     fi
 
     local files_installed=""

--- a/recipes-devtools/rust/cargo-bin-cross.inc
+++ b/recipes-devtools/rust/cargo-bin-cross.inc
@@ -3,11 +3,24 @@ HOMEPAGE = "https://rust-lang.org"
 LICENSE = "Apache-2.0 | MIT"
 SECTION = "devel"
 
+inherit cross
 inherit rust-common
+
+PN = "cargo-bin-cross-${TARGET_ARCH}"
 
 CARGO_HOST_TARGET = "${@rust_target(d, 'HOST')}"
 
-do_install() {
+SYSROOT_DIRS_NATIVE += "${prefix}"
+SYSROOT_DIRS_BLACKLIST += "\
+    ${prefix}/share \
+    ${prefix}/etc \
+"
+
+# Stripping fails because of mixed arch types (host and target)
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+
+fakeroot do_install() {
     ${S}/install.sh --destdir="${D}" --prefix="${prefix}"
     rm -f ${D}${prefix}/lib/rustlib/uninstall.sh
     rm -f ${D}${prefix}/lib/rustlib/install.log
@@ -26,5 +39,3 @@ python () {
     d.setVar("SRC_URI", ' '.join(src_uri + [cargo_uri]))
     d.setVar("S", "{}/{}".format(d.getVar("WORKDIR", True), cargo_url(target).split('/')[-1].replace('.tar.gz', '')))
 }
-
-BBCLASSEXTEND += "native nativesdk"

--- a/recipes-devtools/rust/cargo-bin-cross_1.11.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.11.0.bb
@@ -41,10 +41,10 @@ def cargo_url(triple):
     }
     return get_by_triple(URLS, triple)
 
-DEPENDS += "rust-bin (= 1.11.0)"
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.11.0)"
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
     file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
 "
 
-include cargo-bin.inc
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.12.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.12.0.bb
@@ -1,6 +1,6 @@
 
 # Recipe for cargo 20160821
-# This corresponds to rust release 1.12.1
+# This corresponds to rust release 1.12.0
 
 def get_by_triple(hashes, triple):
     try:
@@ -41,10 +41,10 @@ def cargo_url(triple):
     }
     return get_by_triple(URLS, triple)
 
-DEPENDS += "rust-bin (= 1.12.1)"
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.12.0)"
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
     file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
 "
 
-include cargo-bin.inc
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.12.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.12.1.bb
@@ -1,6 +1,6 @@
 
 # Recipe for cargo 20160821
-# This corresponds to rust release 1.12.0
+# This corresponds to rust release 1.12.1
 
 def get_by_triple(hashes, triple):
     try:
@@ -41,10 +41,10 @@ def cargo_url(triple):
     }
     return get_by_triple(URLS, triple)
 
-DEPENDS += "rust-bin (= 1.12.0)"
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.12.1)"
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
     file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
 "
 
-include cargo-bin.inc
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.14.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.14.0.bb
@@ -41,10 +41,10 @@ def cargo_url(triple):
     }
     return get_by_triple(URLS, triple)
 
-DEPENDS += "rust-bin (= 1.14.0)"
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.14.0)"
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
     file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
 "
 
-include cargo-bin.inc
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.15.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.15.0.bb
@@ -41,10 +41,10 @@ def cargo_url(triple):
     }
     return get_by_triple(URLS, triple)
 
-DEPENDS += "rust-bin (= 1.15.0)"
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.15.0)"
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
     file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
 "
 
-include cargo-bin.inc
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.15.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.15.1.bb
@@ -41,10 +41,10 @@ def cargo_url(triple):
     }
     return get_by_triple(URLS, triple)
 
-DEPENDS += "rust-bin (= 1.15.1)"
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.15.1)"
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
     file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
 "
 
-include cargo-bin.inc
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.16.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.16.0.bb
@@ -41,10 +41,10 @@ def cargo_url(triple):
     }
     return get_by_triple(URLS, triple)
 
-DEPENDS += "rust-bin (= 1.16.0)"
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.16.0)"
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
     file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
 "
 
-include cargo-bin.inc
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.21.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.21.0.bb
@@ -41,10 +41,10 @@ def cargo_url(triple):
     }
     return get_by_triple(URLS, triple)
 
-DEPENDS += "rust-bin (= 1.21.0)"
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.21.0)"
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
     file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
 "
 
-include cargo-bin.inc
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.22.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.22.1.bb
@@ -41,10 +41,10 @@ def cargo_url(triple):
     }
     return get_by_triple(URLS, triple)
 
-DEPENDS += "rust-bin (= 1.22.1)"
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.22.1)"
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
     file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
 "
 
-include cargo-bin.inc
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.23.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.23.0.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20180104
+# This corresponds to rust release 1.23.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "d4df90a25d3932f080cdd3d93285e61d",
+        "arm-unknown-linux-gnueabi": "6606bf8fd070e34821fb3bb2dbce561f",
+        "arm-unknown-linux-gnueabihf": "2df989c6d69db6232fad43b13470ca93",
+        "armv7-unknown-linux-gnueabihf": "31fd607951e227e11c31224107205768",
+        "i686-unknown-linux-gnu": "5f149398a682fac3ee88cfa35cc7339a",
+        "x86_64-unknown-linux-gnu": "830041cfc8627d3f7187954993449cf9",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "c4abbfa2f976d50b814dd5bcafe65bc8a31c551438f106e6d3612aaf78206adb",
+        "arm-unknown-linux-gnueabi": "9b388aaf7e5bcd1498499e19edc851fec14d68da58f1da058f5152db48ea16f2",
+        "arm-unknown-linux-gnueabihf": "f2cd233ecd13759c5cc19329a2fac6b58305b9d675a86a920b3a46d4696cd975",
+        "armv7-unknown-linux-gnueabihf": "78cfc9eb3d8614955bc0d22df3ed971aa259033dfc209cdb9eebf40ea3c2d562",
+        "i686-unknown-linux-gnu": "a3e2d7d53623e239616a49ef80cb17d3e742f75b8c0237d96256b3459caa9cde",
+        "x86_64-unknown-linux-gnu": "ff8a454104aba20426ea898ed7515ec5da7de07d11733cdda17462455beb76e8",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2018-01-04/cargo-0.24.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2018-01-04/cargo-0.24.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2018-01-04/cargo-0.24.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2018-01-04/cargo-0.24.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2018-01-04/cargo-0.24.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2018-01-04/cargo-0.24.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.23.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross.inc
+++ b/recipes-devtools/rust/rust-bin-cross.inc
@@ -6,8 +6,10 @@ SECTION = "devel"
 inherit cross
 inherit rust-common
 
-# Native compiler is installed as a bonus with the cross compiler.
-PROVIDES += "rust-bin-native"
+# Required to link binaries
+DEPENDS += "gcc-cross-${TARGET_ARCH}"
+
+PN = "rust-bin-cross-${TARGET_ARCH}"
 
 # Extra architectures to install standard library for. Must match one of the
 # standard rust targets. The standard library for the default host and target
@@ -20,7 +22,17 @@ RUST_ALL_TARGETS = "${RUST_BUILD_TARGET} ${RUST_TARGET_TARGET} ${EXTRA_RUST_TARG
 
 S = "${WORKDIR}/rustc-${PV}-${RUST_BUILD_TARGET}"
 
-do_install() {
+SYSROOT_DIRS_NATIVE += "${prefix}"
+SYSROOT_DIRS_BLACKLIST += "\
+    ${prefix}/share \
+    ${prefix}/etc \
+"
+
+# Stripping fails because of mixed arch types (host and target)
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+
+fakeroot do_install() {
     # Install rustc
     ${S}/install.sh --destdir="${D}" --prefix="${prefix}"
 
@@ -48,10 +60,4 @@ python () {
                     (base_uri, target, rust_std_md5(target), rust_std_sha256(target)) for target in targets]
     src_uri = d.getVar("SRC_URI", True).split()
     d.setVar("SRC_URI", ' '.join(src_uri + [rustc_src_uri] + std_src_uris))
-}
-
-SYSROOT_PREPROCESS_FUNCS = "rust_process_sysroot"
-rust_process_sysroot() {
-    sysroot_stage_dir ${D}${prefix}/bin ${SYSROOT_DESTDIR}${prefix}/bin
-    sysroot_stage_dir ${D}${prefix}/lib ${SYSROOT_DESTDIR}${prefix}/lib
 }

--- a/recipes-devtools/rust/rust-bin-cross_1.11.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.11.0.bb
@@ -58,4 +58,4 @@ def rustc_sha256(triple):
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 
-include rust-bin.inc
+include rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.12.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.12.0.bb
@@ -58,4 +58,4 @@ def rustc_sha256(triple):
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 
-include rust-bin.inc
+include rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.12.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.12.1.bb
@@ -58,4 +58,4 @@ def rustc_sha256(triple):
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 
-include rust-bin.inc
+include rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.14.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.14.0.bb
@@ -58,4 +58,4 @@ def rustc_sha256(triple):
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 
-include rust-bin.inc
+include rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.15.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.15.0.bb
@@ -58,4 +58,4 @@ def rustc_sha256(triple):
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 
-include rust-bin.inc
+include rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.15.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.15.1.bb
@@ -58,4 +58,4 @@ def rustc_sha256(triple):
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 
-include rust-bin.inc
+include rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.16.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.16.0.bb
@@ -58,4 +58,4 @@ def rustc_sha256(triple):
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=43e1f1fb9c0ee3af66693d8c4fecafa8"
 
-include rust-bin.inc
+include rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.21.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.21.0.bb
@@ -58,4 +58,4 @@ def rustc_sha256(triple):
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c709a09d1b062d9a908e3631c1e1cdf5"
 
-include rust-bin.inc
+include rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.22.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.22.1.bb
@@ -58,4 +58,4 @@ def rustc_sha256(triple):
 
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c709a09d1b062d9a908e3631c1e1cdf5"
 
-include rust-bin.inc
+include rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.23.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.23.0.bb
@@ -1,0 +1,61 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "9c018b6424e6f4f422ad2460e5ff7fe5",
+        "arm-unknown-linux-gnueabi": "1c13d338132e3b3777ec53b340de4761",
+        "arm-unknown-linux-gnueabihf": "70f41fd91be7efa59c06290b287785ae",
+        "armv7-unknown-linux-gnueabihf": "ce11136f6519a4ed87876315061ba37f",
+        "i686-unknown-linux-gnu": "48507590e56854ab5d2bc672b75568da",
+        "mips-unknown-linux-gnu": "9e72aed0c9add269caa32ff7a8529fee",
+        "mipsel-unknown-linux-gnu": "10bb339e10f10d280d9397fb35d090ae",
+        "powerpc-unknown-linux-gnu": "ce877c610496092fd4487bfec6e39893",
+        "x86_64-unknown-linux-gnu": "f9f89caf41e3f9c092118272ceb5bf6b",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "e0e5cca6acec2439bb4925ac43c92f11b7336f8aebec8648d7c49ecb5110a740",
+        "arm-unknown-linux-gnueabi": "803526cf163353235bb26274a43e3c76a4c321a53e43be8cca8a3897c8d12029",
+        "arm-unknown-linux-gnueabihf": "12113afb1def70a6ae27843c37d6a55ec5692a1cf6fe2e518306a1c23756acdc",
+        "armv7-unknown-linux-gnueabihf": "85d0384e8d4b29ab98d8235f304a8ff2dbec6eb483e2eec2867a22f107307776",
+        "i686-unknown-linux-gnu": "e39b3a60898026ad01bdb136e0a58a02a9da61dbbfb348661e6fe199923617a9",
+        "mips-unknown-linux-gnu": "1a504b5965831d376ae9b7af56ec94ed9e84975f867ee34f3bcda88d94abf674",
+        "mipsel-unknown-linux-gnu": "7d504034c3a0c2bfec1132b84a24139900345a5a6ac97341356b3b596b414ad6",
+        "powerpc-unknown-linux-gnu": "8e3efe3e9201f67e2bb959d7947320adc6ab2807e201d714e5fc9b2f2cc143b7",
+        "x86_64-unknown-linux-gnu": "83c7351bdc4326caf785c208cff86682825dad4a89ccee705fa05f55ce7bd25b",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "8a33e0c8b92804a280e2df39ce9184ab",
+        "arm-unknown-linux-gnueabi": "9374f161d94606772acaacdb70d81bec",
+        "arm-unknown-linux-gnueabihf": "868bef7f223a6299f0c148503143769f",
+        "armv7-unknown-linux-gnueabihf": "3162bead042ac3aa0d3a560763a85953",
+        "i686-unknown-linux-gnu": "d38866fdb43baec3c53d05b37e165b1c",
+        "x86_64-unknown-linux-gnu": "068fc6566772c4ce165cc547151f514c",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "26536a06b5f88294780733eae48b8200aba3ef723e6cd649ff641d6d42e48fa8",
+        "arm-unknown-linux-gnueabi": "e7927dea3bfc2eaee42fab5f31cf1b96106b39841c63193be7b7772d381b262a",
+        "arm-unknown-linux-gnueabihf": "56492c6fa722c94c2882d0c10770e69138a653cfecc4e81121b772a0f44e53cc",
+        "armv7-unknown-linux-gnueabihf": "f5166a422c2ce02b97c6c5e699665de10eed61155156857ff780695b6b7ef2db",
+        "i686-unknown-linux-gnu": "bbfd1267f57e70c7e6d3b65e7b5d577c97e647b4326abc890d84acc236a6fc47",
+        "x86_64-unknown-linux-gnu": "27b124fd0d94c082978ff81e45f7b7c37e91d64714587829bf828d64d76524ee",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c709a09d1b062d9a908e3631c1e1cdf5"
+
+require rust-bin-cross.inc


### PR DESCRIPTION
Sometimes you review old code and wonder what exactly you were thinking at the time... In this case, I thought that twice.

First, for my understanding of how to build cross-compiled packages was wrong. I was using nativesdk and native class extensions, when really I needed to `inherit cross` and then change the `PN` of the recipe to match the target architecture. I learned the correct way to deal with this from a close review of the [oe-meta-go](https://github.com/mem/oe-meta-go) recipes.

Second, I was keying off of the `-dbg` package types to determine whether or not to build `--release`. That is also straight-up wrong, since almost all normal builds will not have `-dbg`. I've fixed this by introducing a `CARGO_BUILD_TYPE` variable that can be set if the default of `--release` is not the desired setting.