### PR TITLE
Fix detection of armv7 targets

### DIFF
--- a/classes/rust-common.bbclass
+++ b/classes/rust-common.bbclass
@@ -38,12 +38,15 @@ def rust_target(d, spec_type):
         arch = "x86_64"
     elif arch in ["xscale", "arm", "armv6l", "armv7l"]:
         # Rust requires NEON/VFP in order to build for armv7, else fall back to v6
-        if all(x in tune for x in ["armv7a", "neon", "callconvention-hard"]):
+        tune_armv7 = any(t.startswith("armv7") for t in tune)
+        tune_neon = "neon" in tune
+        tune_cchard = "callconvention-hard" in tune
+        if all([tune_armv7, tune_neon, tune_cchard]):
             arch = "armv7"
             callconvention = "gnueabihf"
         else:
             arch = "arm"
-            if "callconvention-hard" in tune:
+            if tune_cchard:
                 callconvention = "gnueabihf"
             else:
                 callconvention = "gnueabi"

--- a/recipes-devtools/rust/cargo-bin-cross.inc
+++ b/recipes-devtools/rust/cargo-bin-cross.inc
@@ -27,6 +27,7 @@ fakeroot do_install() {
     rm -f ${D}${prefix}/lib/rustlib/components
     rm -f ${D}${prefix}/lib/rustlib/rust-installer-version
 }
+do_install[depends] += "virtual/fakeroot-native:do_populate_sysroot"
 
 python () {
     pv = d.getVar("PV", True)

--- a/recipes-devtools/rust/rust-bin-cross.inc
+++ b/recipes-devtools/rust/rust-bin-cross.inc
@@ -51,6 +51,7 @@ fakeroot do_install() {
     rm -f ${D}${prefix}/lib/rustlib/components
     rm -f ${D}${prefix}/lib/rustlib/rust-installer-version
 }
+do_install[depends] += "virtual/fakeroot-native:do_populate_sysroot"
 
 python () {
     pv = d.getVar("PV", True)


### PR DESCRIPTION
Fix for an issue that @krupatil was seeing - the problem was that for the CPU being used (an i.MX6ULL), the `armv7` TUNE_FEATURE was `armv7ve`, not `armv7a`. That led to the `arm` target being installed instead of `armv7`, and the user package not being able to find the armv7 target.