### PR TITLE
use oe.utils.conditional instead of deprecated base_conditional

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -33,7 +33,7 @@ CARGO_BUILD_FLAGS = "\
     --manifest-path ${S}/Cargo.toml \
     --target=${RUST_TARGET} \
     ${CARGO_BUILD_TYPE} \
-    ${@base_conditional('CARGO_FEATURES', '', '', '--features "${CARGO_FEATURES}"', d)} \
+    ${@oe.utils.conditional('CARGO_FEATURES', '', '', '--features "${CARGO_FEATURES}"', d)} \
     ${EXTRA_CARGO_FLAGS} \
 "
 


### PR DESCRIPTION
This fix errors like `NameError: name 'base_conditional' is not defined` on latest poky master