### PR TITLE
Fix warnings about LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,3 +9,5 @@ BBFILE_PATTERN_rust-bin-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_rust-bin-layer = "7"
 
 LICENSE_PATH += "${LAYERDIR}/files/common-licenses"
+
+LAYERSERIES_COMPAT_rust-bin-layer = "sumo"


### PR DESCRIPTION
LAYERSERIES_COMPAT: Lists the Yocto Project releases for which the current version is compatible. If this variable is not set, bitbake prints a warnings like this:
```
WARNING: Layer rust-bin-layer should set LAYERSERIES_COMPAT_rust-bin-layer in its conf/layer.conf file to list the core layer names it is compatible with.
```

See: https://www.yoctoproject.org/docs/current/mega-manual/mega-manual.html#var-LAYERSERIES_COMPAT