### PR TITLE
Expose Cargo manifest path variable

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -33,9 +33,12 @@ CARGO_DEBUG_DIR = "${B}/${RUST_TARGET}/debug"
 CARGO_RELEASE_DIR = "${B}/${RUST_TARGET}/release"
 WRAPPER_DIR = "${WORKDIR}/wrappers"
 
+# Set the Cargo manifest path to the typical location
+CARGO_MANIFEST_PATH ?= "${S}/Cargo.toml"
+
 CARGO_BUILD_FLAGS = "\
     --verbose \
-    --manifest-path ${S}/Cargo.toml \
+    --manifest-path ${CARGO_MANIFEST_PATH} \
     --target=${RUST_TARGET} \
     ${CARGO_BUILD_TYPE} \
     ${@oe.utils.conditional('CARGO_FEATURES', '', '', '--features "${CARGO_FEATURES}"', d)} \


### PR DESCRIPTION
Creates an overridable variable `CARGO_MANIFEST_PATH` for cases where
the `Cargo.toml` may not be at `${S}` root, such as with multi-crate or
workspace-based repositories.