### PR TITLE
Rust 1.35.0 & 1.34.2

### DIFF
--- a/recipes-devtools/rust/cargo-bin-cross_1.34.2.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.34.2.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20190514
+# This corresponds to rust release 1.34.2
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "65270b99e32c871a0ed862b9f1723620",
+        "arm-unknown-linux-gnueabi": "659c37a45e688be9caa9ff21361d6025",
+        "arm-unknown-linux-gnueabihf": "35d8af25042bc3f36ba80b38bb1c6371",
+        "armv7-unknown-linux-gnueabihf": "b3275b71ad6f7bc13a49aa187531ddfe",
+        "i686-unknown-linux-gnu": "4c23e2209dce37895d6de8b49d15a9bd",
+        "x86_64-unknown-linux-gnu": "72d3ed1d5f17c1c42493d17b1f376aff",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "cf9c88c17e1ad0daa09f690d808210fb08f310bac8ff73924905aef488daab82",
+        "arm-unknown-linux-gnueabi": "4a1858935d30f2c261d815f9f60c0a35aa992a6287cc283497e313c081137475",
+        "arm-unknown-linux-gnueabihf": "a2430ab1d234cb9b1afe8d240b8b98c613735a5e4c19d0a5b50b352227d533b5",
+        "armv7-unknown-linux-gnueabihf": "1b60125aa42cacdd594691619799af5adeabd2533d90dca6c9e495ebb90d89ff",
+        "i686-unknown-linux-gnu": "1345223bd6818e22228b38bcfac45fb5577ac825bf635fcab3c11d3a9f295ecf",
+        "x86_64-unknown-linux-gnu": "1dc3cb681ee275433f3cf751e5736d097b54470e9208dfea18d8ce5505935795",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2019-05-14/cargo-0.35.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2019-05-14/cargo-0.35.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2019-05-14/cargo-0.35.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2019-05-14/cargo-0.35.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2019-05-14/cargo-0.35.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2019-05-14/cargo-0.35.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.34.2)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.35.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.35.0.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20190523
+# This corresponds to rust release 1.35.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "ce56c5d1969cbdc331b4a11049c9253d",
+        "arm-unknown-linux-gnueabi": "3071830ad012ed7735a7d0a53831c418",
+        "arm-unknown-linux-gnueabihf": "b64e715c4baa91c8cfab16a0c4c81eeb",
+        "armv7-unknown-linux-gnueabihf": "94f0e3e71736d5093f8d8d4c2c091f73",
+        "i686-unknown-linux-gnu": "6f4e447b0b4a842dcf92a8838dc63b50",
+        "x86_64-unknown-linux-gnu": "79aae88fdbee04d5d89eec76fef67c10",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "f118e65111623cdee6648dc16d04daae8eb77dcbbfc8847d95e36e8316aa7736",
+        "arm-unknown-linux-gnueabi": "a0f91639223246bccc81ea6544dc74c17a1b6b5b8d9a0d034d317bbfa9140670",
+        "arm-unknown-linux-gnueabihf": "f4ee2b5392bdb9956df455083c3c28dfa57e36a22abef30846dce5325741d313",
+        "armv7-unknown-linux-gnueabihf": "54d9cbc72c2953ed0e22a34e46d697276b903b5329e9aa6c407f79864aca94f7",
+        "i686-unknown-linux-gnu": "6ef32560bfa7c85dee6ef932a5e35994457f3e05e2cf8979c19971b8a5b805e4",
+        "x86_64-unknown-linux-gnu": "77586f2fb5b6f6caef0cb6d3cc32a18559d4fcd6a6db4e75f4b3fb7adb050437",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2019-05-23/cargo-0.36.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2019-05-23/cargo-0.36.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2019-05-23/cargo-0.36.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2019-05-23/cargo-0.36.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2019-05-23/cargo-0.36.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2019-05-23/cargo-0.36.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.35.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=1836efb2eb779966696f473ee8540542 \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.34.2.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.34.2.bb
@@ -1,0 +1,61 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "b4833cbb4d56ca2e21bebafa92f6fe29",
+        "arm-unknown-linux-gnueabi": "875f7a721fb2a6440ac390cb4426d07a",
+        "arm-unknown-linux-gnueabihf": "e05665df5c50cc554beb8ac90355284d",
+        "armv7-unknown-linux-gnueabihf": "9fd59ee9a00e9b8df88033ff68295e79",
+        "i686-unknown-linux-gnu": "8ee160a2e1763ab45371dd50d18c50e2",
+        "mips-unknown-linux-gnu": "057c35a9685419ba862b593f72e4f38b",
+        "mipsel-unknown-linux-gnu": "7282751064a9cda449d2139e94c0723a",
+        "powerpc-unknown-linux-gnu": "39e593f8f7a70c026a0e4f84df8228a7",
+        "x86_64-unknown-linux-gnu": "77f724de6319193beead06c00f3f5efd",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "921545fc9cfa49f9f1d73764bfd49bf19059356ece3beaa7ae0546215e8d06c4",
+        "arm-unknown-linux-gnueabi": "203789cd534196abfe95d64b68d3578fde240edac789fb55c0010e3afd73d6c8",
+        "arm-unknown-linux-gnueabihf": "cec42e631bceef33d009606ac4d1f48d0b5a6cff8f087843c5857e05ff65ec4d",
+        "armv7-unknown-linux-gnueabihf": "38e398aae478acd8e624f0e26bf8912cb0e323d0516d368f2cd3627f831a5b86",
+        "i686-unknown-linux-gnu": "781bbdd39d90d14ec63b8c110e300299254650f50e2fd8c808a3a4125471905c",
+        "mips-unknown-linux-gnu": "01959e7f5132e8da640a12c70a346b228496ced293af7d66af30abf5089043c6",
+        "mipsel-unknown-linux-gnu": "14e962ce0a19a8d647948b594fa52d6c280113d38ee9f19848d3ad8a977f2095",
+        "powerpc-unknown-linux-gnu": "a7a611a787af01f982826fe70f26ae2c119c742c8f3dbbad3f49b72f017ae028",
+        "x86_64-unknown-linux-gnu": "904950e877759b32afa57e024298d7ed19c72db3fb94890057a3deb070021896",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "740923cb834baaae614887300275b990",
+        "arm-unknown-linux-gnueabi": "382033477af184d35953852206795a0c",
+        "arm-unknown-linux-gnueabihf": "8af4d1ffd8cbc5a119c1312bc9faea44",
+        "armv7-unknown-linux-gnueabihf": "f6c7f9c0efcf9eea6dda1e1559f47c47",
+        "i686-unknown-linux-gnu": "ef5897ccc13fa2e1b5bee2a201d2d1ac",
+        "x86_64-unknown-linux-gnu": "f76f83120f1a3912ac39d94bd4cbc130",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "ed00299078a991cb8a2473f5292cad3378df59c4b762b0bdd3089bf2508a53f8",
+        "arm-unknown-linux-gnueabi": "9bd24aff99eda252ecdfb401434554e4f7cf3854331d5ed886a1be2a87cc35b8",
+        "arm-unknown-linux-gnueabihf": "0d030173edb7fecbcf32d8a18396fe712b6079e4264f34aaba1e2e6a975b04a6",
+        "armv7-unknown-linux-gnueabihf": "eaf10f3424700b4dddf6503e296d2789e1e7d73f9b0316a6aa24b39067e2a18d",
+        "i686-unknown-linux-gnu": "55947cdbc8f107b940b000c2269342ed49be20bb159692d3565abe174e4b5610",
+        "x86_64-unknown-linux-gnu": "6feecd115bd2072a1109a4afbc320dd21d23a2bd1f2d99d5377757fbb9272fc8",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.35.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.35.0.bb
@@ -1,0 +1,61 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        bb.fatal("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "801ff1a95c92f3acab57738a67e23b26",
+        "arm-unknown-linux-gnueabi": "dafaa4e1c1f081cafe8c7b5a689deb43",
+        "arm-unknown-linux-gnueabihf": "19a8e6e4a4336bc3103b63c9f7de8fac",
+        "armv7-unknown-linux-gnueabihf": "0bf8a78c8c23241f3943cf79dacfe66e",
+        "i686-unknown-linux-gnu": "458d8f7465372ce8ccce163c6af63243",
+        "mips-unknown-linux-gnu": "7a6edcc9d6cd98025cddf247bef9027c",
+        "mipsel-unknown-linux-gnu": "8c6dad7f9d4f78ef245e5bb17838333e",
+        "powerpc-unknown-linux-gnu": "1f7262bc0bddf32c7fa1420084dbc5f0",
+        "x86_64-unknown-linux-gnu": "5c58d2b6b7d9b9a600d36742b5391b94",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "eee3c6a5c7ef5bc21b626ce350b0e1b02310e0463b6686683262f3fef400746d",
+        "arm-unknown-linux-gnueabi": "fa3b53ac36eaddb5250985a2af8bfcff9c8a3baf60262b01c11594c2a1583d79",
+        "arm-unknown-linux-gnueabihf": "8a8b31c3c1086219a10f2bffd6f8bcd13da8b254e8162dbd79a38b33bde49fa4",
+        "armv7-unknown-linux-gnueabihf": "8f62b615b728e38ab350eaf4f20a81c423e1ac33b51b945960500380326ce248",
+        "i686-unknown-linux-gnu": "ab41c886af02a16a9a38780043d7f3da24c637629afa222b38f616fe6de86402",
+        "mips-unknown-linux-gnu": "3276d1be3ca2942115bf5918277c1d00c38dd639630279749cde4de6b544df45",
+        "mipsel-unknown-linux-gnu": "3edabc96c999400725050c2f330482752b2c6b7076c4210f5874e7e0ac20ed71",
+        "powerpc-unknown-linux-gnu": "6998070a6bc56ffa788078cb2afa28e1c54c88f70091e319f3ac3a45e8bce40f",
+        "x86_64-unknown-linux-gnu": "5dfa92661ff1a22680785bd6999b6117ae66841e2bd9e5318eb97002956131e4",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "5f8cddd52b96e4ebd5db6609b0966dd6",
+        "arm-unknown-linux-gnueabi": "812bc08a98b8bbb20e41ded92f62bfe1",
+        "arm-unknown-linux-gnueabihf": "9e26ef9fc4698a49f458241e2ce54b6c",
+        "armv7-unknown-linux-gnueabihf": "44c1de5e74c0c9ca79a05b0f36b6fb16",
+        "i686-unknown-linux-gnu": "5a7d7128e98e0c62d82c748cddb8496c",
+        "x86_64-unknown-linux-gnu": "2942b5ffa86e243b46f20fe3ac2f4d64",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "dc06d77e6cdc06693d3b87ce473f151c96bda2c1e5dbba8c0354c54990c64fc2",
+        "arm-unknown-linux-gnueabi": "04b87df1511333321bdb68d1da5fb3c98949b7baa8507ede8c8b911ca160ac2d",
+        "arm-unknown-linux-gnueabihf": "c7a0a4ffcdd26c0dabe8e1e985f877c9bb0b0354ef35476460c97f3c0e14b733",
+        "armv7-unknown-linux-gnueabihf": "4eb787ac84d5368c1323160134d641145826a0f5d5b42066752533eb572503e1",
+        "i686-unknown-linux-gnu": "b05ca05cfb6f106f92283bb06158845f29abb3c1145a8dc306d2aa210f42d106",
+        "x86_64-unknown-linux-gnu": "bb3a07a1f2fdc3eeeee25fc40131d3f05494e3838dfd4e9275475ffc500d7a9e",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"
+
+require rust-bin-cross.inc


### PR DESCRIPTION
Adds the latest stable Rust and the latest patch version of 1.34.