### PR TITLE
fix: double-evaluation of escaped variables in wrappers

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -70,19 +70,19 @@ cargo_do_configure() {
     # the compiler binary. cargo/rustc expect a single binary, so we put ${CC}
     # in a wrapper script.
     echo "#!/bin/sh" >"${WRAPPER_DIR}/cc-wrapper.sh"
-    echo "${CC} \$@" >>"${WRAPPER_DIR}/cc-wrapper.sh"
+    echo "${CC} \"\$@\"" >>"${WRAPPER_DIR}/cc-wrapper.sh"
     chmod +x "${WRAPPER_DIR}/cc-wrapper.sh"
 
     echo "#!/bin/sh" >"${WRAPPER_DIR}/cc-native-wrapper.sh"
-    echo "${BUILD_CC} \$@" >>"${WRAPPER_DIR}/cc-native-wrapper.sh"
+    echo "${BUILD_CC} \"\$@\"" >>"${WRAPPER_DIR}/cc-native-wrapper.sh"
     chmod +x "${WRAPPER_DIR}/cc-native-wrapper.sh"
 
     echo "#!/bin/sh" >"${WRAPPER_DIR}/linker-wrapper.sh"
-    echo "${CC} ${LDFLAGS} \$@" >>"${WRAPPER_DIR}/linker-wrapper.sh"
+    echo "${CC} ${LDFLAGS} \"\$@\"" >>"${WRAPPER_DIR}/linker-wrapper.sh"
     chmod +x "${WRAPPER_DIR}/linker-wrapper.sh"
 
     echo "#!/bin/sh" >"${WRAPPER_DIR}/linker-native-wrapper.sh"
-    echo "${BUILD_CC} ${BUILD_LDFLAGS} \$@" >>"${WRAPPER_DIR}/linker-native-wrapper.sh"
+    echo "${BUILD_CC} ${BUILD_LDFLAGS} \"\$@\"" >>"${WRAPPER_DIR}/linker-native-wrapper.sh"
     chmod +x "${WRAPPER_DIR}/linker-native-wrapper.sh"
 
     # Create our global config in CARGO_HOME


### PR DESCRIPTION
Time for another round of guess the obscure shell issue!

The existing implementation of the wrapper scripts (cc-wrapper, linker-wrapper, et. al.) was passing any additional arguments to the compiler by using just `$@`. This is different than `"$@"` - while it seems like `"$@"` would put all arguments into a single, quoted expansion, it actually has a special meaning that passes arguments as-is to the underlying program being called.

This was discovered when an additional argument to the cc-wrapper script, which was properly escaped initially, caused a failure to build using meta-rust-bin because escaped quotes were being evaluated twice. It's easiest to see in an example.

The Rust crate being compiled calls out to the C compiler, i.e. our script, as follows:

    cc-wrapper.sh "MY_ARG=\"value with spaces\""

The initial call is properly escaped - i.e. cc-wrapper sees the arg as MY_ARG="value with spaces", a single argument. However, previously using `$@` this was expanded again when calling the compiler:

    gcc MY_ARG="value with spaces"

In this case the arguments to gcc are passed as

    $1: MY_ARG="value
    $2: with
    $3: spaces"

Using `"$@"` instead avoids the extra parsing, passing the argument to gcc as intended.

Good reference SO post: https://stackoverflow.com/questions/3008695/what-is-the-difference-between-and-in-bash

CC @jmagnuson @elbe0046 @GeorgeHahn 