### PR TITLE
cargo: Fix cross compiling check to use RUST_BUILD and RUST_TARGET

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -50,7 +50,7 @@ create_cargo_config() {
     echo "[target.${RUST_BUILD}]" >> ${CARGO_HOME}/config
     echo "linker = '${WRAPPER_DIR}/linker-native-wrapper.sh'" >> ${CARGO_HOME}/config
 
-    if [ "${HOST_SYS}" != "${TARGET_SYS}" ]; then
+    if [ "${RUST_BUILD}" != "${RUST_TARGET}" ]; then
         echo >> ${CARGO_HOME}/config
         echo "[target.${RUST_TARGET}]" >> ${CARGO_HOME}/config
         echo "linker = '${WRAPPER_DIR}/linker-wrapper.sh'" >> ${CARGO_HOME}/config


### PR DESCRIPTION
The check, for this specific layer case, must be done using the Rust
specific targets as the vendor of toolchain is ignored blindly.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>