### PR TITLE
arm arch tune varibles have been moved to MACHINEOVERRIDES in Warrior

### DIFF
--- a/classes/rust-common.bbclass
+++ b/classes/rust-common.bbclass
@@ -26,6 +26,7 @@ def rust_target(d, spec_type):
     # TUNE_FEATURES are always only for the TARGET
     if spec_type == "TARGET":
         tune = d.getVar("TUNE_FEATURES", True).split()
+        tune += d.getVar("MACHINEOVERRIDES", True).split(":")
     else:
         tune = []
 


### PR DESCRIPTION
This change essentially address an issue caused by upstream changes in the
poky repo around arch and cpu specific tunes.  Changes shown in the referenced
commit are causing target rust libraries to not being installed correctly in the
sysroot-native path resulting in compilation failures as shown below

For reference - this is the commit in the poky repo
https://git.yoctoproject.org/cgit.cgi/poky/commit/meta/conf/machine/include?h=warrior&id=156a2d98600299822695d173381a9eac49e30908

(In this example an armv7 cpu is being used, however, the installed lib dir is incorrectly installed)
recipe-sysroot-native/usr/lib/rustlib/
├── arm-unknown-linux-gnueabihf
│   └── lib
├── etc
└── x86_64-unknown-linux-gnu
    ├── bin
    ├── codegen-backends
    └── lib

which causes failures such as:
error[E0463]: can't find crate for `core`
  |
  = note: the `armv7-unknown-linux-gnueabihf` target may not be installed

After the changes:
recipe-sysroot-native/usr/lib/rustlib
├── armv7-unknown-linux-gnueabihf
│   └── lib
├── etc
└── x86_64-unknown-linux-gnu
    ├── bin
    ├── codegen-backends
    └── lib

Signed-off-by: Kevin Vanden Berge <kevin@smartthings.com>