### PR TITLE
Add target aarch64-unknown-linux-musl

### DIFF
--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -142,7 +142,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 EOF
@@ -238,7 +238,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -21,6 +21,7 @@ cd "$TMPDIR"
 
 TARGET_TRIPLES=(
     aarch64-unknown-linux-gnu
+    aarch64-unknown-linux-musl
     arm-unknown-linux-gnueabi
     arm-unknown-linux-gnueabihf
     armv7-unknown-linux-gnueabihf

--- a/recipes-devtools/rust/cargo-bin-cross_1.11.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.11.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.12.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.12.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.12.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.12.1.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.14.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.14.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.15.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.15.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.15.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.15.1.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.16.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.16.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.21.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.21.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.22.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.22.1.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.23.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.23.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.24.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.24.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.25.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.25.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.26.2.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.26.2.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.27.2.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.27.2.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.28.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.28.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.30.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.30.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.30.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.30.1.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.31.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.31.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.32.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.32.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.33.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.33.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.34.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.34.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.34.2.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.34.2.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.35.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.35.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.36.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.36.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.37.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.37.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.38.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.38.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.39.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.39.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/cargo-bin-cross_1.40.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.40.0.bb
@@ -6,7 +6,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 def cargo_md5(triple):
     HASHES = {

--- a/recipes-devtools/rust/rust-bin-cross_1.11.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.11.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.12.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.12.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.12.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.12.1.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.14.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.14.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.15.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.15.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.15.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.15.1.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.16.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.16.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.21.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.21.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.22.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.22.1.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.22.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.22.1.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "4333cf381c0a76eab20c763654ce7e27",
+        "aarch64-unknown-linux-musl": "184c4c90a4adb4f3c95663af70b136c8",
         "arm-unknown-linux-gnueabi": "bf00db914952878c771f61b1f39c4168",
         "arm-unknown-linux-gnueabihf": "8c1e10b73a348ff4426b0754c3b691dd",
         "armv7-unknown-linux-gnueabihf": "061d300e8754bac2fa56cea776ba485c",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "8ceb35380cffa7b07a14401236660b59b73f9d6abb156c33a6d23c30d15827cc",
+        "aarch64-unknown-linux-musl": "89808d4517806242d22732ef5b68c4bb5884d84ba479c884669999a841587b4e",
         "arm-unknown-linux-gnueabi": "9326fe0463f30bbffde98b4e6bcbdea65d60fd106cf4a914a1477ab308e6aa92",
         "arm-unknown-linux-gnueabihf": "6dc1845abfdec6e7963addbd0dcb3b5144bac2d9dc8f29f9f63289d16d67960a",
         "armv7-unknown-linux-gnueabihf": "17da76a8fe849e5de63566b41a7ef5d9f0b588d889b0118566d48617417961a8",

--- a/recipes-devtools/rust/rust-bin-cross_1.23.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.23.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.23.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.23.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "9c018b6424e6f4f422ad2460e5ff7fe5",
+        "aarch64-unknown-linux-musl": "b2db60094aa241f14946b8996264fff2",
         "arm-unknown-linux-gnueabi": "1c13d338132e3b3777ec53b340de4761",
         "arm-unknown-linux-gnueabihf": "70f41fd91be7efa59c06290b287785ae",
         "armv7-unknown-linux-gnueabihf": "ce11136f6519a4ed87876315061ba37f",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "e0e5cca6acec2439bb4925ac43c92f11b7336f8aebec8648d7c49ecb5110a740",
+        "aarch64-unknown-linux-musl": "c382790d0e635ddd8925d57d7cc69ff8f2c892be0a40f5efeb60b8b66e0ae909",
         "arm-unknown-linux-gnueabi": "803526cf163353235bb26274a43e3c76a4c321a53e43be8cca8a3897c8d12029",
         "arm-unknown-linux-gnueabihf": "12113afb1def70a6ae27843c37d6a55ec5692a1cf6fe2e518306a1c23756acdc",
         "armv7-unknown-linux-gnueabihf": "85d0384e8d4b29ab98d8235f304a8ff2dbec6eb483e2eec2867a22f107307776",

--- a/recipes-devtools/rust/rust-bin-cross_1.24.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.24.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.24.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.24.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "9e1db18dc4686e79ec6aabc29198ac9f",
+        "aarch64-unknown-linux-musl": "5b1cc5e2838de024b7af71f03ec9210e",
         "arm-unknown-linux-gnueabi": "4c0633ed46b931820ca09d9ce3e6ec2b",
         "arm-unknown-linux-gnueabihf": "60421020fb09201c28c7ccd77cd4e3d1",
         "armv7-unknown-linux-gnueabihf": "aeed3afd353fb940cffde6d313a8634e",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "4a2305f934c66b02cf3d903d21147a642a2a9f28872b9e1bbe14e2d54e19ab09",
+        "aarch64-unknown-linux-musl": "227ae8617e2b320dfbb5372263eb5f57711f309711ab87ee38d0e94246a07d33",
         "arm-unknown-linux-gnueabi": "ae38ddb14da6e70f937749aefecefc02fdefb87f4a053496cd62ffbae75aae6e",
         "arm-unknown-linux-gnueabihf": "6f89414c6eddb8acd461f78274cff5a9496d7edf01524f733e4f8b766a08887f",
         "armv7-unknown-linux-gnueabihf": "2379cb0cd66fccbfaa4f208e99803086879cdd8b1aad4b875196a6bf9148db63",

--- a/recipes-devtools/rust/rust-bin-cross_1.25.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.25.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "6c4ad81415bca48ac330e366311b8a7e",
+        "aarch64-unknown-linux-musl": "c31b839a67bd5a430f6704e2688bee49",
         "arm-unknown-linux-gnueabi": "3e1a27b11f17428290a6133a1b0211c8",
         "arm-unknown-linux-gnueabihf": "1c4d35eaf252f66b2266b31dedef88f8",
         "armv7-unknown-linux-gnueabihf": "9e0610fa920f4a442fd05a54cb7b1b8b",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "1dc571379b63532227d87a24c6c34848016717e12222270a612ea213cce808bf",
+        "aarch64-unknown-linux-musl": "68b8c641645668dab1570cafe87c73d0a838c523b3208350f51270ad861ffb77",
         "arm-unknown-linux-gnueabi": "d37ec9e1954b866e0cac5a0fbe10d46bd2ae4b1e3b2a7f1d1b184ea8f84582b2",
         "arm-unknown-linux-gnueabihf": "4490cc593924ff49a3c4a832ccfd2c5bdaa8be0e023eee5ef66341a3caab1f74",
         "armv7-unknown-linux-gnueabihf": "04adb1e7775c27f761a8cfb1d0a1960ebf4ff74dee0e60b44d7bcde50fdb76d2",

--- a/recipes-devtools/rust/rust-bin-cross_1.25.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.25.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.26.2.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.26.2.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "11e34cf93738338e0f2c0a61c56d6e12",
+        "aarch64-unknown-linux-musl": "ef27a68bdfd03e19a3ca1a635448e3cd",
         "arm-unknown-linux-gnueabi": "f1562b674761de60d0352f7db808261a",
         "arm-unknown-linux-gnueabihf": "110f26f2e2e341c15b04d9c867db17e6",
         "armv7-unknown-linux-gnueabihf": "e86f288440aa251bcdcd6bc22d0faba1",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "6f629b8c3ef8aa4a6c9439a5c1d8719905853f321a1080bb9f8a8356a1b06364",
+        "aarch64-unknown-linux-musl": "d70817352ebe34fab475ef3cd79ccbd56cf20e3b9ae0b34a285dd1c966bf2bde",
         "arm-unknown-linux-gnueabi": "b8e6cd048ef21195386caa6f204a0480d102715a53f6ff55a9df687b75dd3652",
         "arm-unknown-linux-gnueabihf": "79ea9e2c993ad047a86c4c347c08afaafa4280a659cfb6f156869a5730f58e4c",
         "armv7-unknown-linux-gnueabihf": "420d6cff015215f47a407b19c9b5f97dbca402818e4093636bee53c966c3e6ad",

--- a/recipes-devtools/rust/rust-bin-cross_1.26.2.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.26.2.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.27.2.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.27.2.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.27.2.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.27.2.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "7de9a2bc70fc142eccee00d1ff6c7fd6",
+        "aarch64-unknown-linux-musl": "99f558e32f9a0af9a0e958ab3e3b2eb4",
         "arm-unknown-linux-gnueabi": "6fb4507dc3ff617100868580fb498347",
         "arm-unknown-linux-gnueabihf": "7d60da9e5c8bd151a8d1d3787ffaa455",
         "armv7-unknown-linux-gnueabihf": "4956e94e61703b8446fdad068035dc54",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "39bafd1db4f1e881cdbd8d81b757bfef1cad6c06f6aa4514f8b693d997764e2a",
+        "aarch64-unknown-linux-musl": "5e8e6d5368ece8c822991c8b4437e83d0537f253cb70b39d627d17f012813122",
         "arm-unknown-linux-gnueabi": "6c21611a435ad69b0356745a1c46ea8c4c5b6f505c91fb6f7140d47975b531d9",
         "arm-unknown-linux-gnueabihf": "40bbeeb9fcf61e26051626b0dd68d0d70b740dbc2572a9df5450dfc369fac573",
         "armv7-unknown-linux-gnueabihf": "ce22f7487b711f63207a040bef039442176415ae9383e6a7f574a6afcd3654cc",

--- a/recipes-devtools/rust/rust-bin-cross_1.28.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.28.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "a78cea44233a1d89cb223a0ca0ab078e",
+        "aarch64-unknown-linux-musl": "1053749da5f342151abeb5ee0df316e9",
         "arm-unknown-linux-gnueabi": "1ab544d8d097d19e7b96d649e1bee1d6",
         "arm-unknown-linux-gnueabihf": "bf939d3b4632ab73c2d6b6ea4fb118d3",
         "armv7-unknown-linux-gnueabihf": "e970ec17cbf90c34f5c5e6011768ebf0",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "9ba698f68c5643f53934e1085af40c79c6d1b3bfa01ca6dcdffdc5eec8f44cc0",
+        "aarch64-unknown-linux-musl": "b1acdf055d534f4ce295271fe6101833c65261aeb52ffb619911a4db3de35663",
         "arm-unknown-linux-gnueabi": "26dff0b6e2196e04565a555d95952d7fd7ced3a95fdcfd96e37666a26902177d",
         "arm-unknown-linux-gnueabihf": "b1761c6981e802e6851af12f625acaf8af2ad4cb743a813ea57eef57927fbc4f",
         "armv7-unknown-linux-gnueabihf": "6811d49d312c06b0f0e67604e1ab90f899c66ab942a37b3ac46b5b1f6a5a03c7",

--- a/recipes-devtools/rust/rust-bin-cross_1.28.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.28.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.30.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.30.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.30.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.30.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "a6b1946a6455f427cf389db8e8d4cb0d",
+        "aarch64-unknown-linux-musl": "00321de7f0eaa126ecdbb2ad4d8155a4",
         "arm-unknown-linux-gnueabi": "89e6171576151a551ef45ea8dc807500",
         "arm-unknown-linux-gnueabihf": "45f2b4c5004f4c275e5cd4c7f9c8904a",
         "armv7-unknown-linux-gnueabihf": "1ccf4f0b46d24a11a0918d98514332eb",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "0166650de5072545c3945416638dec9beec5ae1f3c72069e314b7c50e18b4819",
+        "aarch64-unknown-linux-musl": "03ea73844f2963e1716661142a15fc39b8dc026b2654ababe009d31df4e78363",
         "arm-unknown-linux-gnueabi": "2dc5e1e0af871eb6b2ef2152821bd8e7d8ad77e7e9efa805a86f2cc3919e6851",
         "arm-unknown-linux-gnueabihf": "d3a337315774f8ff4afe7854f59daac96e3c0e08bbc216a2cc3efc83d30f4f7a",
         "armv7-unknown-linux-gnueabihf": "ecbb41147795d17958b21e9e15314d9ff143ab932bcfcdca408aa6f6d6603a75",

--- a/recipes-devtools/rust/rust-bin-cross_1.30.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.30.1.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "fd418a7252c80c892a04ca462a77ac0e",
+        "aarch64-unknown-linux-musl": "045da7a3d39ba53b10d34e4c88eee556",
         "arm-unknown-linux-gnueabi": "abadeb3a32348919170d32acf7d8a6da",
         "arm-unknown-linux-gnueabihf": "1bfcdb7d5ebb18dabf0e798f9c588c1e",
         "armv7-unknown-linux-gnueabihf": "8717c64f4edbd7febe232c62a3d02b8d",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "64410910d73628a77dfe94dbcd0cd49709b518b5f641fbe4a2476b9af097d47b",
+        "aarch64-unknown-linux-musl": "0bdcb6fcf904d0b047d75e0368caf1d29380c62ba5c54254ca8ad777e1e7b5ba",
         "arm-unknown-linux-gnueabi": "8c2ea7c66a86450561234df8d07e4cff6519db93626a149496e187690dca4aeb",
         "arm-unknown-linux-gnueabihf": "cd21b66e983a390ecbef87fafebf35f299759dbc821e6f775cc49c57d16a0f9d",
         "armv7-unknown-linux-gnueabihf": "18c6cbe62105f2808ba8fcb785e5dc69e540e6fd1ab21dd0f3f2a6dac33c17bf",

--- a/recipes-devtools/rust/rust-bin-cross_1.30.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.30.1.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.31.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.31.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "ccdde68be2a1c7a58fa5ae8199e51f41",
+        "aarch64-unknown-linux-musl": "1ee2058ab3b17e9e2f9917ffe5b86df7",
         "arm-unknown-linux-gnueabi": "f3a8b6d9b8991ad07e65e6052c6cef05",
         "arm-unknown-linux-gnueabihf": "595794e45cf1e06e78457fb33e85ec27",
         "armv7-unknown-linux-gnueabihf": "a4c30bd57ce9dd611a73ad74460ecb61",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "02e5b48d8fff293a95b591646e707a8c61399ab6c244508ed842f3d736ded641",
+        "aarch64-unknown-linux-musl": "3cedc72a9754219f1684e7037ed10866f0cd756d6ecfaffcd2ef8d57374f85b0",
         "arm-unknown-linux-gnueabi": "fcffdf979ecbe9cf7352cb0795dfd073292506c7ff24da2bf0913fca29c0109f",
         "arm-unknown-linux-gnueabihf": "28395a84180ec528404c13b9958c6fd65bd02c68d7d10dfd760364104e4252f1",
         "armv7-unknown-linux-gnueabihf": "fea5b5f47b4b0f6464d3297f3d4425389f7aedea5ebbb64b2eb27275c1915126",

--- a/recipes-devtools/rust/rust-bin-cross_1.31.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.31.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.32.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.32.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.32.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.32.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "9095163ce2e5a32452ac9fa82c34fab3",
+        "aarch64-unknown-linux-musl": "d8da48434fbe6bd6d2859f72efd472f7",
         "arm-unknown-linux-gnueabi": "79542666656986631d5f9e6a0fc5deb4",
         "arm-unknown-linux-gnueabihf": "7e6b8991537031404161fe8f57a29cad",
         "armv7-unknown-linux-gnueabihf": "6909a564b31ba45539e6db455250680d",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "346efe3aef2aff7b71a611bf7661bcec5f9bc4025a599c2866ec5fd330247cb9",
+        "aarch64-unknown-linux-musl": "ca67a0ae151de83e077b95dfca459ca2445db461c7e6428c11a32e23e8ea9525",
         "arm-unknown-linux-gnueabi": "154a885326a8c88d7e57cce1a9986ed181c359763b3559d6d429a1e41c93e282",
         "arm-unknown-linux-gnueabihf": "fae70593f70281b5f4f7d6dd258f10748e90ff3c6b14bd5f7adc698b82a5ea4f",
         "armv7-unknown-linux-gnueabihf": "ac6946bb4df718905fc1b9411c624941d69d3382f3584ee1cb0031936c700b2e",

--- a/recipes-devtools/rust/rust-bin-cross_1.33.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.33.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.33.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.33.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "028b1371c8a02295543619a6c023d1cc",
+        "aarch64-unknown-linux-musl": "612017dca358a7b9bd24eb52dea4e65e",
         "arm-unknown-linux-gnueabi": "ea06a51ad0a4dd04e81dbec42cb298f0",
         "arm-unknown-linux-gnueabihf": "c5b57e8478ef710f0675043fc1accd0d",
         "armv7-unknown-linux-gnueabihf": "4ebd0a2686181eb6f645de10cf171a2d",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "26f13cd80c95d484ccffecf517f1e05ce521072a00f1adea43d02b3f9d37f82a",
+        "aarch64-unknown-linux-musl": "47c7ed55b77e161c9489ca903be32be80dd0efdf88d55f472bb54cce832629de",
         "arm-unknown-linux-gnueabi": "71e5e752e092fee4b75e039b2dca131ece1cd9abbe55aec0180ad818f36b28e5",
         "arm-unknown-linux-gnueabihf": "2ceb92bc8cda753db1a6a333c40c1d78d4cd86ba1ab4cecd3ecc7d13149f6cac",
         "armv7-unknown-linux-gnueabihf": "ae7801238f4f1c50ba12687169ebfb611dc22c5c9541ff80fd0b3f7165ed7f27",

--- a/recipes-devtools/rust/rust-bin-cross_1.34.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.34.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "eaba79af7a595baa57a417c1f216f74f",
+        "aarch64-unknown-linux-musl": "7feca93fee9004d64a93ada5eb9650d7",
         "arm-unknown-linux-gnueabi": "a5a6a98734b48223918b5a74e5a4912f",
         "arm-unknown-linux-gnueabihf": "fcf772289f097185ed661ba45c2795a2",
         "armv7-unknown-linux-gnueabihf": "0502601842e318bc1df7394a4eb00c46",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "d175e91206aba9e2056a9c5af50f700502e70b2f8eb609854d660ac2f3bf1fff",
+        "aarch64-unknown-linux-musl": "2b08cf5b0fdd2cd71e7aece36587fb4869e53faace966eaddb2e2c5fb908eb74",
         "arm-unknown-linux-gnueabi": "d04b676975be4798aaac8b36bde4f9fad62653504db23022995c796a29cafa4d",
         "arm-unknown-linux-gnueabihf": "b5ac48988463123a8b10520ce48ed6c4c359d21ee006812c091c656f10e9f49b",
         "armv7-unknown-linux-gnueabihf": "c74d6f1d93509ade62ffb4a1111e90c87fa16db5cd2a6b0792d523561386f6d1",

--- a/recipes-devtools/rust/rust-bin-cross_1.34.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.34.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.34.2.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.34.2.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.34.2.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.34.2.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "b4833cbb4d56ca2e21bebafa92f6fe29",
+        "aarch64-unknown-linux-musl": "33958f2dffa1178869e8dd997bc54273",
         "arm-unknown-linux-gnueabi": "875f7a721fb2a6440ac390cb4426d07a",
         "arm-unknown-linux-gnueabihf": "e05665df5c50cc554beb8ac90355284d",
         "armv7-unknown-linux-gnueabihf": "9fd59ee9a00e9b8df88033ff68295e79",
@@ -23,6 +24,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "921545fc9cfa49f9f1d73764bfd49bf19059356ece3beaa7ae0546215e8d06c4",
+        "aarch64-unknown-linux-musl": "e2c2f2d434c2f908938cbdced8f802eedae9325788e1d870238c2dc525517f0c",
         "arm-unknown-linux-gnueabi": "203789cd534196abfe95d64b68d3578fde240edac789fb55c0010e3afd73d6c8",
         "arm-unknown-linux-gnueabihf": "cec42e631bceef33d009606ac4d1f48d0b5a6cff8f087843c5857e05ff65ec4d",
         "armv7-unknown-linux-gnueabihf": "38e398aae478acd8e624f0e26bf8912cb0e323d0516d368f2cd3627f831a5b86",

--- a/recipes-devtools/rust/rust-bin-cross_1.35.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.35.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "801ff1a95c92f3acab57738a67e23b26",
+        "aarch64-unknown-linux-musl": "79c8f109f16eda6c714bfa04bfdd8f43",
         "arm-unknown-linux-gnueabi": "dafaa4e1c1f081cafe8c7b5a689deb43",
         "arm-unknown-linux-gnueabihf": "19a8e6e4a4336bc3103b63c9f7de8fac",
         "armv7-unknown-linux-gnueabihf": "0bf8a78c8c23241f3943cf79dacfe66e",
@@ -24,6 +25,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "eee3c6a5c7ef5bc21b626ce350b0e1b02310e0463b6686683262f3fef400746d",
+        "aarch64-unknown-linux-musl": "518ba1fb0c0020856eb06ecf3d4d11b94b2ffb0b5f318aac9e086be9b0be2ccd",
         "arm-unknown-linux-gnueabi": "fa3b53ac36eaddb5250985a2af8bfcff9c8a3baf60262b01c11594c2a1583d79",
         "arm-unknown-linux-gnueabihf": "8a8b31c3c1086219a10f2bffd6f8bcd13da8b254e8162dbd79a38b33bde49fa4",
         "armv7-unknown-linux-gnueabihf": "8f62b615b728e38ab350eaf4f20a81c423e1ac33b51b945960500380326ce248",

--- a/recipes-devtools/rust/rust-bin-cross_1.35.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.35.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.36.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.36.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "ef3b5caad66200710dd4c8689f1e8eab",
+        "aarch64-unknown-linux-musl": "047e63c51ec16924227504b329b413ef",
         "arm-unknown-linux-gnueabi": "e8c1646642250372e61a7b59c2f04a05",
         "arm-unknown-linux-gnueabihf": "0662d61f9a10bf22de36a3289e891249",
         "armv7-unknown-linux-gnueabihf": "9246f2b0e21c5358c9ada5076eb20277",
@@ -24,6 +25,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "22bfc32b5003c3d5259babb202f3f66be16fa6f3c75c20f429a16d7ef5eb1928",
+        "aarch64-unknown-linux-musl": "42778ab5f87d2dbfc6849fcf0c6e0a3760b18e8c89385130da0a1953d5fed147",
         "arm-unknown-linux-gnueabi": "6322100c43960e598a8b6efceabe3a1851e00fac9fb8268769e351af23762d26",
         "arm-unknown-linux-gnueabihf": "a4253ddee2aa9cbf47ee64aeb87a34f22d8246d4e7985b782472e2aed0390f86",
         "armv7-unknown-linux-gnueabihf": "3519091d0d83a551c77d65b2187c0e0874b4c3aad962f144ad7dd5f7246fba84",

--- a/recipes-devtools/rust/rust-bin-cross_1.36.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.36.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.37.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.37.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "3d8653f13e05af99b771b6119f49d622",
+        "aarch64-unknown-linux-musl": "dc46eb4490fcaee9af5e96ab27a853d7",
         "arm-unknown-linux-gnueabi": "60d0230ca3fd8fc62b314b017356f967",
         "arm-unknown-linux-gnueabihf": "c1e031c3f1b4fe23890eeabc346f51b5",
         "armv7-unknown-linux-gnueabihf": "4274ffcc4c368f2513f50398c9f6d2ac",
@@ -24,6 +25,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "60d64dde9178fdb698b44315b182375916116e30f5fe7f0d8278dd62eb15e7b3",
+        "aarch64-unknown-linux-musl": "68db64972c1af5d4d0c4b3d62b644d158df149eed4197e1c26e93ae4a81e4860",
         "arm-unknown-linux-gnueabi": "709351f2d3329faf6fb5c2474ce8e06ec0fa77c2ffa7fa80f9696ddfa45c4cd4",
         "arm-unknown-linux-gnueabihf": "3e0f58fb599bfb0a9d106d4f6b7cdb27d833a9fb62ec0554e809bd29883ddc40",
         "armv7-unknown-linux-gnueabihf": "d5e0a86515b102f0b7a541e324d3e49b0346b02e8cc388bcf84a8bf48da4680d",

--- a/recipes-devtools/rust/rust-bin-cross_1.37.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.37.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.38.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.38.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.38.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.38.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "5f529c926cebad570acb5fb9abe57849",
+        "aarch64-unknown-linux-musl": "59c066da694d3ead23e6c0a3086d57b6",
         "arm-unknown-linux-gnueabi": "87cb674dc93bea07b2d01d517ecec16a",
         "arm-unknown-linux-gnueabihf": "9981fcb151c5251b49b7021f1538767a",
         "armv7-unknown-linux-gnueabihf": "52a03fdacdf5d18dac5e5bff93fcf2a1",
@@ -24,6 +25,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "0725ae9f55639c648fdaba06129de395ed839a7d1aab6aebfd21f26cbe1ce7ca",
+        "aarch64-unknown-linux-musl": "56268f0c7c93a4f3436aa20af75e80e29e7d651c754b076c64f13219f2e6be8a",
         "arm-unknown-linux-gnueabi": "2e1446aa281f463736eb8a52555712c9be0740339f3921408beb7cdbb2f47aef",
         "arm-unknown-linux-gnueabihf": "19d572ee9319b24fcd4edbb90b3649d8dec2ccd7a183427fa5f62e6743d8e90d",
         "armv7-unknown-linux-gnueabihf": "28d1e31c1a7dda1c183d217ca0d6cddcd7ae936e8ba6d562846a33695f991d78",

--- a/recipes-devtools/rust/rust-bin-cross_1.39.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.39.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):

--- a/recipes-devtools/rust/rust-bin-cross_1.39.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.39.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "6f67b384089ac16fe1b38c7310523c5a",
+        "aarch64-unknown-linux-musl": "99292c96d95b10531da5b575e5a8fd85",
         "arm-unknown-linux-gnueabi": "9a05ee0cd393cb76bc675aca082d912a",
         "arm-unknown-linux-gnueabihf": "383522e26872f6c119d6df15945786db",
         "armv7-unknown-linux-gnueabihf": "4145c34db4d86aecdb1d8bde0af2b139",
@@ -24,6 +25,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "adbecacf6cf0ed19df2496cc648b16192c0bd085d7e6f670edcea4dd28ab37df",
+        "aarch64-unknown-linux-musl": "1d4a3640fa6e696180848ac2eb10ccc7904acac58784b27e5fcd8a79b2cdf0fa",
         "arm-unknown-linux-gnueabi": "2001f86ea2df468386b8196ec8e8eead81f6b7a9631f662d66140a35cd674b2e",
         "arm-unknown-linux-gnueabihf": "4865141256b0bcc3c190368fc9db874317f66e78a7bb90a97ef191ace9eb7384",
         "armv7-unknown-linux-gnueabihf": "172770e4004fec166792fdb329afb344c2714e2b9b96c377725dfb9a173496c9",

--- a/recipes-devtools/rust/rust-bin-cross_1.40.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.40.0.bb
@@ -9,6 +9,7 @@ def get_by_triple(hashes, triple):
 def rust_std_md5(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "5d6539e7872c77647d8bd0c223d69acc",
+        "aarch64-unknown-linux-musl": "dc56345f6d452ef4338cd20a85bf9b3d",
         "arm-unknown-linux-gnueabi": "24dcf42bfab48799fbbaafdcbc8af2f9",
         "arm-unknown-linux-gnueabihf": "1cc61b9a679408326a8dc3016fcf4663",
         "armv7-unknown-linux-gnueabihf": "3043dd404da88627b06519bc42977419",
@@ -24,6 +25,7 @@ def rust_std_md5(triple):
 def rust_std_sha256(triple):
     HASHES = {
         "aarch64-unknown-linux-gnu": "e1a1bc577d51556c53e39d4f11fb4918f0ebf27e166ff63321b2991754706d16",
+        "aarch64-unknown-linux-musl": "5a269c83446da52c824b3c2047d66540f524e79901ac09b2ac80900a692849dc",
         "arm-unknown-linux-gnueabi": "540fcfc3c21adac1155acf4ae751e80f675793f4e615fd1e246ff2299d3a8b54",
         "arm-unknown-linux-gnueabihf": "704e1f497d8f1a71dc80b56d0aa286fc8eb847aa6d3c5df88ca5d2209005acf5",
         "armv7-unknown-linux-gnueabihf": "4c7ea8544e2b6e9401ac73b657f06e401d924fcf80f3e4c1448c4d17c3818fb1",

--- a/recipes-devtools/rust/rust-bin-cross_1.40.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.40.0.bb
@@ -3,7 +3,7 @@ def get_by_triple(hashes, triple):
     try:
         return hashes[triple]
     except:
-        bb.fatal("Unsupported triple: %s" % triple)
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
 
 
 def rust_std_md5(triple):


### PR DESCRIPTION
This PR adds support for target aarch64-unknown-linux-musl. Since Rust releases before 1.22.1 did not release binaries for aarch64-unknown-linux-musl, avoid a fatal error when parsing those recipes by raising SkipRecipe instead of calling bb.fatal.