### PR TITLE
Fix CXX compiler errors.

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -77,9 +77,17 @@ cargo_do_configure() {
     echo "${CC} \"\$@\"" >>"${WRAPPER_DIR}/cc-wrapper.sh"
     chmod +x "${WRAPPER_DIR}/cc-wrapper.sh"
 
+    echo "#!/bin/sh" >"${WRAPPER_DIR}/cxx-wrapper.sh"
+    echo "${CXX} \"\$@\"" >>"${WRAPPER_DIR}/cxx-wrapper.sh"
+    chmod +x "${WRAPPER_DIR}/cxx-wrapper.sh"
+
     echo "#!/bin/sh" >"${WRAPPER_DIR}/cc-native-wrapper.sh"
     echo "${BUILD_CC} \"\$@\"" >>"${WRAPPER_DIR}/cc-native-wrapper.sh"
     chmod +x "${WRAPPER_DIR}/cc-native-wrapper.sh"
+
+    echo "#!/bin/sh" >"${WRAPPER_DIR}/cxx-native-wrapper.sh"
+    echo "${BUILD_CXX} \"\$@\"" >>"${WRAPPER_DIR}/cxx-native-wrapper.sh"
+    chmod +x "${WRAPPER_DIR}/cxx-native-wrapper.sh"
 
     echo "#!/bin/sh" >"${WRAPPER_DIR}/linker-wrapper.sh"
     echo "${CC} ${LDFLAGS} \"\$@\"" >>"${WRAPPER_DIR}/linker-wrapper.sh"
@@ -95,7 +103,9 @@ cargo_do_configure() {
 
 cargo_do_compile() {
     export TARGET_CC="${WRAPPER_DIR}/cc-wrapper.sh"
+    export TARGET_CXX="${WRAPPER_DIR}/cxx-wrapper.sh"
     export CC="${WRAPPER_DIR}/cc-native-wrapper.sh"
+    export CXX="${WRAPPER_DIR}/cxx-native-wrapper.sh"
     export TARGET_LD="${WRAPPER_DIR}/ld-wrapper.sh"
     export LD="${WRAPPER_DIR}/ld-native-wrapper.sh"
     export PKG_CONFIG_ALLOW_CROSS="1"


### PR DESCRIPTION
Could it be that wrappers are also needed for the `CXX` compiler? Without this modification I'm unable the compile the `zmq` crate (with vendored ZeroMQ source). See below:

---

```
   process didn't exit successfully: `/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/target/release/build/zmq-sys-21a1e6ece6cec0e5/build-script-main` (exit code: 101)
| --- stdout
| cargo:rerun-if-changed=build/main.rs
| cargo:rerun-if-env-changed=PROFILE
| running: "cmake" "/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/cargo_home/registry/src/github.com-1ecc6299db9ec823/zeromq-src-0.1.8+4.3.2/vendor" "-DCMAKE_INSTALL_LIBDIR=lib" "-DCMAKE_C_STANDARD=99" "-DZMQ_BUILD_TESTS=OFF" "-DENABLE_DRAFTS=OFF" "-DCMAKE_BUILD_TYPE=Release" "-DWITH_PERF_TOOL=OFF" "-DBUILD_SHARED=OFF" "-DBUILD_STATIC=ON" "-DWITH_LIBSODIUM=OFF" "-DCMAKE_INSTALL_PREFIX=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/target/arm-unknown-linux-gnueabihf/release/build/zmq-sys-7be6e4b26214ac55/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -march=armv6 -marm -mfpu=vfp -pipe -feliminate-unused-debug-types -fmacro-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10=/usr/src/debug/chirpstack-concentratord-sx1301/3.0.0-test.5-r10 -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10=/usr/src/debug/chirpstack-concentratord-sx1301/3.0.0-test.5-r10 -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot= -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native=" "-DCMAKE_C_COMPILER=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/wrappers/cc-wrapper.sh" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -march=armv6 -marm -mfpu=vfp -pipe -feliminate-unused-debug-types -fmacro-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10=/usr/src/debug/chirpstack-concentratord-sx1301/3.0.0-test.5-r10 -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10=/usr/src/debug/chirpstack-concentratord-sx1301/3.0.0-test.5-r10 -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot= -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native= -fvisibility-inlines-hidden" "-DCMAKE_CXX_COMPILER=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/arm-oe-linux-gnueabi-g++"
| -- The C compiler identification is GNU 9.2.0
| -- The CXX compiler identification is GNU 9.2.0
| -- Check for working C compiler: /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/wrappers/cc-wrapper.sh
| -- Check for working C compiler: /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/wrappers/cc-wrapper.sh -- works
| -- Detecting C compiler ABI info
| -- Detecting C compiler ABI info - done
| -- Detecting C compile features
| -- Detecting C compile features - done
| -- Check for working CXX compiler: /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/arm-oe-linux-gnueabi-g++
| -- Check for working CXX compiler: /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/arm-oe-linux-gnueabi-g++ -- broken
| -- Configuring incomplete, errors occurred!
| See also "/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/target/arm-unknown-linux-gnueabihf/release/build/zmq-sys-7be6e4b26214ac55/out/build/CMakeFiles/CMakeOutput.log".
| See also "/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/target/arm-unknown-linux-gnueabihf/release/build/zmq-sys-7be6e4b26214ac55/out/build/CMakeFiles/CMakeError.log".
|
| --- stderr
| CMake Error at /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/share/cmake-3.15/Modules/CMakeTestCXXCompiler.cmake:53 (message):
|   The C++ compiler
|
|     "/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/arm-oe-linux-gnueabi-g++"
|
|   is not able to compile a simple test program.
|
|   It fails with the following output:
|
|     Change Dir: /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/target/arm-unknown-linux-gnueabihf/release/build/zmq-sys-7be6e4b26214ac55/out/build/CMakeFiles/CMakeTmp
|
|     Run Build Command(s):/build/tmp/raspberrypi/raspberrypi-glibc/hosttools/make cmTC_6a29d/fast && make -f CMakeFiles/cmTC_6a29d.dir/build.make CMakeFiles/cmTC_6a29d.dir/build
|     make[1]: Entering directory '/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/target/arm-unknown-linux-gnueabihf/release/build/zmq-sys-7be6e4b26214ac55/out/build/CMakeFiles/CMakeTmp'
|     Building CXX object CMakeFiles/cmTC_6a29d.dir/testCXXCompiler.cxx.o
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/arm-oe-linux-gnueabi-g++    -ffunction-sections -fdata-sections -fPIC -march=armv6 -marm -mfpu=vfp -pipe -feliminate-unused-debug-types -fmacro-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10=/usr/src/debug/chirpstack-concentratord-sx1301/3.0.0-test.5-r10 -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10=/usr/src/debug/chirpstack-concentratord-sx1301/3.0.0-test.5-r10 -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot= -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native= -fvisibility-inlines-hidden    -o CMakeFiles/cmTC_6a29d.dir/testCXXCompiler.cxx.o -c /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/target/arm-unknown-linux-gnueabihf/release/build/zmq-sys-7be6e4b26214ac55/out/build/CMakeFiles/CMakeTmp/testCXXCompiler.cxx
|     Linking CXX executable cmTC_6a29d
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_6a29d.dir/link.txt --verbose=1
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/arm-oe-linux-gnueabi-g++   -ffunction-sections -fdata-sections -fPIC -march=armv6 -marm -mfpu=vfp -pipe -feliminate-unused-debug-types -fmacro-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10=/usr/src/debug/chirpstack-concentratord-sx1301/3.0.0-test.5-r10 -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10=/usr/src/debug/chirpstack-concentratord-sx1301/3.0.0-test.5-r10 -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot= -fdebug-prefix-map=/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native= -fvisibility-inlines-hidden     -rdynamic CMakeFiles/cmTC_6a29d.dir/testCXXCompiler.cxx.o  -o cmTC_6a29d
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find crt1.o: No such file or directory
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find crti.o: No such file or directory
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find crtbegin.o: No such file or directory
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find -lstdc++
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find -lm
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find -lgcc_s
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find -lgcc
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find -lc
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find -lgcc_s
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find -lgcc
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find crtend.o: No such file or directory
|     /build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/recipe-sysroot-native/usr/bin/arm-oe-linux-gnueabi/../../libexec/arm-oe-linux-gnueabi/gcc/arm-oe-linux-gnueabi/9.2.0/ld: cannot find crtn.o: No such file or directory
|     collect2: error: ld returned 1 exit status
|     make[1]: *** [CMakeFiles/cmTC_6a29d.dir/build.make:87: cmTC_6a29d] Error 1
|     make[1]: Leaving directory '/build/tmp/raspberrypi/raspberrypi-glibc/work/arm1176jzfshf-vfp-oe-linux-gnueabi/chirpstack-concentratord-sx1301/3.0.0-test.5-r10/target/arm-unknown-linux-gnueabihf/release/build/zmq-sys-7be6e4b26214ac55/out/build/CMakeFiles/CMakeTmp'
|     make: *** [Makefile:121: cmTC_6a29d/fast] Error 2
|

```