### PR TITLE
Add RUSTFLAGS support

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -22,6 +22,8 @@ RUST_BUILD = "${@rust_target(d, 'BUILD')}"
 
 # Additional flags passed directly to the "cargo build" invocation
 EXTRA_CARGO_FLAGS ??= ""
+EXTRA_RUSTFLAGS ??= ""
+RUSTFLAGS= "${EXTRA_RUSTFLAGS}"
 
 # Space-separated list of features to enable
 CARGO_FEATURES ??= ""
@@ -114,8 +116,8 @@ cargo_do_compile() {
     bbnote "rustc --version" `rustc --version`
     bbnote "which cargo:" `which cargo`
     bbnote "cargo --version" `cargo --version`
-    bbnote cargo build ${CARGO_BUILD_FLAGS}
-    cargo build ${CARGO_BUILD_FLAGS}
+    bbnote ${RUSTFLAGS} cargo build ${CARGO_BUILD_FLAGS}
+    RUSTFLAGS="${RUSTFLAGS}" cargo build ${CARGO_BUILD_FLAGS}
 }
 
 cargo_do_install() {

--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -23,7 +23,7 @@ RUST_BUILD = "${@rust_target(d, 'BUILD')}"
 # Additional flags passed directly to the "cargo build" invocation
 EXTRA_CARGO_FLAGS ??= ""
 EXTRA_RUSTFLAGS ??= ""
-RUSTFLAGS= "${EXTRA_RUSTFLAGS}"
+RUSTFLAGS += "${EXTRA_RUSTFLAGS}"
 
 # Space-separated list of features to enable
 CARGO_FEATURES ??= ""
@@ -112,12 +112,13 @@ cargo_do_compile() {
     export LD="${WRAPPER_DIR}/ld-native-wrapper.sh"
     export PKG_CONFIG_ALLOW_CROSS="1"
     export LDFLAGS=""
+    export RUSTFLAGS="${RUSTFLAGS}"
     bbnote "which rustc:" `which rustc`
     bbnote "rustc --version" `rustc --version`
     bbnote "which cargo:" `which cargo`
     bbnote "cargo --version" `cargo --version`
-    bbnote ${RUSTFLAGS} cargo build ${CARGO_BUILD_FLAGS}
-    RUSTFLAGS="${RUSTFLAGS}" cargo build ${CARGO_BUILD_FLAGS}
+    bbnote cargo build ${CARGO_BUILD_FLAGS}
+    cargo build ${CARGO_BUILD_FLAGS}
 }
 
 cargo_do_install() {


### PR DESCRIPTION
this change allows `RUSTFLAGS` to be passed to the cargo build command, i.e. you can add this to your recipe append file : `EXTRA_RUSTFLAGS="-C target-cpu=cortex-a75"` or enable debug symbol in a release build `EXTRA_RUSTFLAGS="-g"`