### PR TITLE
class/cargo: Handle case when host and target has same arch

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -48,12 +48,16 @@ CARGO_BUILD_FLAGS = "\
 "
 
 create_cargo_config() {
-    echo > ${CARGO_HOME}/config
-    echo "[target.${RUST_BUILD}]" >> ${CARGO_HOME}/config
-    echo "linker = '${WRAPPER_DIR}/linker-native-wrapper.sh'" >> ${CARGO_HOME}/config
-
     if [ "${RUST_BUILD}" != "${RUST_TARGET}" ]; then
+        echo > ${CARGO_HOME}/config
+        echo "[target.${RUST_BUILD}]" >> ${CARGO_HOME}/config
+        echo "linker = '${WRAPPER_DIR}/linker-native-wrapper.sh'" >> ${CARGO_HOME}/config
+
         echo >> ${CARGO_HOME}/config
+        echo "[target.${RUST_TARGET}]" >> ${CARGO_HOME}/config
+        echo "linker = '${WRAPPER_DIR}/linker-wrapper.sh'" >> ${CARGO_HOME}/config
+    else
+        echo > ${CARGO_HOME}/config
         echo "[target.${RUST_TARGET}]" >> ${CARGO_HOME}/config
         echo "linker = '${WRAPPER_DIR}/linker-wrapper.sh'" >> ${CARGO_HOME}/config
     fi


### PR DESCRIPTION
When we have same architecture for the host and target, we need to
properly handle the native and target case as Rust cannot differentiate
both.

Fixes: #70.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>