### PR TITLE
Stop on download error

### DIFF
--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -44,7 +44,7 @@ RUSTC_TRIPLES=(
 
 download() {
     echo "download $@"
-    curl -# -O $@
+    curl --fail -# -O $@
 }
 
 dlfile() {


### PR DESCRIPTION
At the moment, the `build-new-version.sh` happily continues even if a download failed (e.g. due to a 404). This fixes that.