### PR TITLE
update to latest compiler

### DIFF
--- a/recipes-devtools/rust/cargo-bin-cross_1.47.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.47.0.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20201008
+# This corresponds to rust release 1.47.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "a20e459ef915b0b287734ef2c051dcee",
+        "arm-unknown-linux-gnueabi": "ed04b4098911a64acb3df26f49ae412e",
+        "arm-unknown-linux-gnueabihf": "1ab359086d8ed0fbb2600273f846601d",
+        "armv7-unknown-linux-gnueabihf": "1aa6653b10f1c8eaa8aada865415373c",
+        "i686-unknown-linux-gnu": "8c2b0309f17f77650d01dabf6be707e8",
+        "x86_64-unknown-linux-gnu": "b610d900230b7e294d8a2a778d18cd20",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "3421561a71918f8327841a7f982fcbb1b187d918988698a8fe8a51fba9e360cf",
+        "arm-unknown-linux-gnueabi": "9578cb400b75dda9408e34ed9c2c18b555d751776ae3fd17c566f09fff7cdc75",
+        "arm-unknown-linux-gnueabihf": "fcc8088549e36b112455a61032dd10a3e7d569d3eb11d087fb5f451dfe994d92",
+        "armv7-unknown-linux-gnueabihf": "4c5eccd10092a344d8e62370509617a21556f98a141d9412677bc5b5bf6f3460",
+        "i686-unknown-linux-gnu": "d10fed01c128e1d2a5af29c604b321ef1c37994f250c55799d66ec2126f73381",
+        "x86_64-unknown-linux-gnu": "e53b8bf28603a28c09c6e8dd4d0045adefe86457642f1dc68c2a71b54b04f202",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2020-10-08/cargo-0.48.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2020-10-08/cargo-0.48.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2020-10-08/cargo-0.48.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2020-10-08/cargo-0.48.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2020-10-08/cargo-0.48.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2020-10-08/cargo-0.48.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.47.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.48.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.48.0.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20201119
+# This corresponds to rust release 1.48.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "a617e4d459ceb64387afbfa2f4026db4",
+        "arm-unknown-linux-gnueabi": "94dc3a5c07e05632111ee6b6df8d074b",
+        "arm-unknown-linux-gnueabihf": "0c2cf5ada48903f2f3f60223f8626002",
+        "armv7-unknown-linux-gnueabihf": "e5b777dd4708f7f00e6dcbbcea694673",
+        "i686-unknown-linux-gnu": "7c3bba8d47dcdb2f7660e094e0326425",
+        "x86_64-unknown-linux-gnu": "8f37221a49aebf41e15e27c3133273dd",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "71347016f0da96d4250225f7b52701274df958870b1a65482badb87d661035f9",
+        "arm-unknown-linux-gnueabi": "9e98f4d471c94b1c736a42674d73f516ea852617b6207777f682929e7e7f4a7b",
+        "arm-unknown-linux-gnueabihf": "2f4ab9e5f4e7fd17a16bbc1aa102b65a264f832df9693caef78d6f7a56885fa6",
+        "armv7-unknown-linux-gnueabihf": "da8d28d6a51edc5826e53d512c0bcb74ae1fdfef07b2a371c51b64072c960828",
+        "i686-unknown-linux-gnu": "b67758a6be3c19654daf779937e8ff7c8d5fbf3d0e65ceed1f08f5cd753d8b8f",
+        "x86_64-unknown-linux-gnu": "52bf632e337a5e7464cb961766638e30dfa28edb3036428296678d1aaf7d8ede",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2020-11-19/cargo-1.48.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2020-11-19/cargo-1.48.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2020-11-19/cargo-1.48.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2020-11-19/cargo-1.48.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2020-11-19/cargo-1.48.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2020-11-19/cargo-1.48.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.48.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.49.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.49.0.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20201231
+# This corresponds to rust release 1.49.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "2ba3a6a4f8cedbb5f662cada79421435",
+        "arm-unknown-linux-gnueabi": "26384352f6a31122064a21545b010728",
+        "arm-unknown-linux-gnueabihf": "d7bc4b9c7b88a315c38f8db101f21a64",
+        "armv7-unknown-linux-gnueabihf": "3bf8cece9cf178e3335ea6918a78db5f",
+        "i686-unknown-linux-gnu": "b759115afc83c0fd645e393da4576248",
+        "x86_64-unknown-linux-gnu": "4a201aca6b3bea98a45eb681c95521bb",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "fce2bd0eabf9a9958b02f5ede3c227c992ee7048ab34293cce57bc3d48e63fc0",
+        "arm-unknown-linux-gnueabi": "509d1be6f1cb751e86238e163c11da5a3c60694117530194ed1a858fc0129466",
+        "arm-unknown-linux-gnueabihf": "52c1df52ce3e6175f7ca9f5c6851127312b7c10ca0265d0c4dac2a0702895bcf",
+        "armv7-unknown-linux-gnueabihf": "3269e9be467ea3d8fc0fab21e81b01dba71791a9020e123125d2fafed9b6cc91",
+        "i686-unknown-linux-gnu": "90ec7eb7272a3b0a3c4e7d25eac0341ca14c55f168d385006f77c6b1dd0df836",
+        "x86_64-unknown-linux-gnu": "900597323df24703a38f58e40ede5c3f70e105ddc296e2b90efe6fe2895278fe",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2020-12-31/cargo-1.49.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2020-12-31/cargo-1.49.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2020-12-31/cargo-1.49.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2020-12-31/cargo-1.49.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2020-12-31/cargo-1.49.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2020-12-31/cargo-1.49.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.49.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.47.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.47.0.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "78cde5ab9fded29e2d32f28aac30c451",
+        "aarch64-unknown-linux-musl": "9825f3457eb5f264bbaa55f6094253c3",
+        "arm-unknown-linux-gnueabi": "ba2f5dcad204f1274ba4cf8ca3a39704",
+        "arm-unknown-linux-gnueabihf": "35c3be632766487e93ab22da5e6e905d",
+        "armv5te-unknown-linux-gnueabi": "e983c7b7a8d3f04d5b3a3be0b3cd4748",
+        "armv5te-unknown-linux-musleabi": "49248522ec55b317f38277a2247d4004",
+        "armv7-unknown-linux-gnueabihf": "98e40088d5393b4ad8c2a341dc385e2c",
+        "armv7-unknown-linux-musleabihf": "17b605546e9a3b1688956b6cbc39490a",
+        "i686-unknown-linux-gnu": "8db4e38a2254ce5eb5dcb5b7de47ddad",
+        "mips-unknown-linux-gnu": "22e2306df51e151b2dcfc7887923406d",
+        "mipsel-unknown-linux-gnu": "4e6fdc2a119215ca1ba1750f839bc16f",
+        "powerpc-unknown-linux-gnu": "618069bb5baaab595f6c0041b54cd5e2",
+        "x86_64-unknown-linux-gnu": "b998b73cf7137b8c0deeeda0ae0ca876",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "0019c302a0a02d8a9e40c3bcdd5a31b9b2704161563d72df3572521989182b0c",
+        "aarch64-unknown-linux-musl": "69e27f17038a4eb99fe43781f0ca6432f64802bb24fd08fd4f2b90dc73987396",
+        "arm-unknown-linux-gnueabi": "0091b20243bcd93bd71a0a40ada0dbb823fbc94ee89aba884aef65e8c1963175",
+        "arm-unknown-linux-gnueabihf": "06f81e14b008e55fc3623cc165e45f3494585cf13d8bd0cb04934eb203e8b136",
+        "armv5te-unknown-linux-gnueabi": "2e73be12c4b37cc0380c76be1a4f929ae98fe9251b3c7972e716c8831cf0f3b2",
+        "armv5te-unknown-linux-musleabi": "29221665f68db676361a7856473577f62f59a9697b32bf912fb96a083be8ad3a",
+        "armv7-unknown-linux-gnueabihf": "0d732f9035cc315102b589b1219b4ff3aabe7b254e92996d2b78e264ff500cd4",
+        "armv7-unknown-linux-musleabihf": "904db62c505fed767d67434ec8cfb90fab7e30557014d312062292472a0887ff",
+        "i686-unknown-linux-gnu": "2a5b8e26c3b61046ab9f420d905b680779cb5521a64b3d2a1846f5dab68c0ba7",
+        "mips-unknown-linux-gnu": "7f0cb7552045e1dacd7b7a026d58e7cccf3ec997c19b2f6e571b3e954cb1d078",
+        "mipsel-unknown-linux-gnu": "f79e4d1c84fe4551c3526fd67e686febf5b9defc48fbbd48c9455c2d033c55f2",
+        "powerpc-unknown-linux-gnu": "bef6ba913c34230931cf2db1345d2626930a260bb19605e48de26aa8ffc7f7d3",
+        "x86_64-unknown-linux-gnu": "17ecad27d96b331608e4a96dfa3cad05ccb2ccecb888894ed35054e0d1f5207f",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "c2dcb2437c1da3408c5caffafa0415e1",
+        "arm-unknown-linux-gnueabi": "7b93c5fdc75e3b4a77cf928f160cdb82",
+        "arm-unknown-linux-gnueabihf": "7342137408d0bf3fff77cabed6ee5d57",
+        "armv7-unknown-linux-gnueabihf": "242340a64d1060f541fca50d57498f44",
+        "i686-unknown-linux-gnu": "eef43be80d36de14e5fc19ff713c8cd7",
+        "x86_64-unknown-linux-gnu": "a247f5c9aa4e0d278a110a853626a166",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "2e143bfa59eca5c3f3e995c5997ae55c7defe824fb4dbe7e77896e132f42c24b",
+        "arm-unknown-linux-gnueabi": "ae67d4eb065e397ea8ef4d00a70cfe72bc3097bcab0a8d4c0b5bd2377469c906",
+        "arm-unknown-linux-gnueabihf": "e25cf5a8c91f829ac1230fbd854cee45a9befd8a459134da87fa072c4a145399",
+        "armv7-unknown-linux-gnueabihf": "603b01f7481909f6b033a38e73da00dc9664b903bf2b0ba8d506b505e3b35500",
+        "i686-unknown-linux-gnu": "8ae62e7d9ab28714d3dbf83c48319895fbda0fb069f6a9b94f3cddaa2b174aa7",
+        "x86_64-unknown-linux-gnu": "d96be0ae1deada01f41372ab2c2f485a9f8625069aeaff33c5b513061e9706d4",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.48.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.48.0.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "ac98d4e7541f2375b6c86c2dc417d827",
+        "aarch64-unknown-linux-musl": "7fcdb1e47cd8f37fd2834fcf58e3f56e",
+        "arm-unknown-linux-gnueabi": "83a17189c2c9f428aa70e50f35b7c55a",
+        "arm-unknown-linux-gnueabihf": "799d7e367f6e8af661f70671a3ae8c4b",
+        "armv5te-unknown-linux-gnueabi": "5db48da84114dfa81033e63c86b7fe90",
+        "armv5te-unknown-linux-musleabi": "82d6397e9575fc4309e49c49c881019a",
+        "armv7-unknown-linux-gnueabihf": "e5a41ed5809dc84a573c9dc4fcee2de9",
+        "armv7-unknown-linux-musleabihf": "5273541a34f7d1e5ca84fb529d78f0ea",
+        "i686-unknown-linux-gnu": "f4b90198482f61d402514c5035811302",
+        "mips-unknown-linux-gnu": "c4ab4228bf1f6d3e37e62ebb2d129411",
+        "mipsel-unknown-linux-gnu": "2a41037086ed1e04e41afddef18bcfcb",
+        "powerpc-unknown-linux-gnu": "8256f8e1b597049d54b9643c16da11f0",
+        "x86_64-unknown-linux-gnu": "064f6d8f88d946de1f657e64d241a70d",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "3b0e5c4d03ddb97cd462947c539005427813f5ba91be81888db77e7d4bf36e45",
+        "aarch64-unknown-linux-musl": "29be0b241bd14651bf9d470a9766000b424a112a0b4a6160f422b075e4668c4c",
+        "arm-unknown-linux-gnueabi": "e206f39ef804ea117a99158be7dc10cc0405636c836d7ec1a74229bd997a46e5",
+        "arm-unknown-linux-gnueabihf": "6bcd9a9376bd7141c76c6faf82acbc8689ba5ac50f2c1405a7beef568f15ce8c",
+        "armv5te-unknown-linux-gnueabi": "ebe1a44ce5046f69e1ef4c18c0f35e6d0abeda702046e7b2984345ad2d7e371e",
+        "armv5te-unknown-linux-musleabi": "c67769e69abe205e6e0d9014be66322fe27cd1d31d59fbe69334b4b342ecd761",
+        "armv7-unknown-linux-gnueabihf": "ec2413e4afbfa3a674fef789896ef66b1d4986367d6402ed1c59e66c4a0163aa",
+        "armv7-unknown-linux-musleabihf": "f2f1da7d2f1934526d8934bba03bb0a28b1268b5f986511347b97206159b0a82",
+        "i686-unknown-linux-gnu": "caa71db54348d40f1729f4a6119e09f56a8c131158c9ed9447b96540d45ff43c",
+        "mips-unknown-linux-gnu": "e9b00ee38a325438be7c58c608fe24fe2f46115dd16a6bf16ae605261e99d1fa",
+        "mipsel-unknown-linux-gnu": "0d00e5b4a1e9bad5f245652c8703c392e4ff2e8f8a2e34cc67584596fd37c5a5",
+        "powerpc-unknown-linux-gnu": "977889fe30ec1aaeda6b25a1b3c9231cd8e7f3a1447b14c748e1b0e806e2faa7",
+        "x86_64-unknown-linux-gnu": "2e7152e5d24cea7e44e6645ebbc0387cbe1c7059b54d95d8ea3afe298ac8b2fc",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "04a3c4488d9f14ece5cd67f01edffd07",
+        "arm-unknown-linux-gnueabi": "cf12d0e17d8287e042c9d597342edd94",
+        "arm-unknown-linux-gnueabihf": "6afd3200a7d732e7d58b1052a3313993",
+        "armv7-unknown-linux-gnueabihf": "de43523ee1b12266088ed0f30a6f8de6",
+        "i686-unknown-linux-gnu": "239a22ea161d6ced49806b9fc3742eb6",
+        "x86_64-unknown-linux-gnu": "029e67ed544605f3eacec875f5b95165",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "9c83a5d18f6ca913eeffd78c53913da288b171ff245137b646a8fd280fe72340",
+        "arm-unknown-linux-gnueabi": "f0e84a682cdf890554efd75d03d46ffc3467c51f7f4b2c8167ddc2e374ed2111",
+        "arm-unknown-linux-gnueabihf": "77a4bc6cc7fb857989a96e57c86f12e827f858a00f0770a04d5fab888a9a3383",
+        "armv7-unknown-linux-gnueabihf": "88030908dad49ae17f67428edb6348a8b4b05dd7ae92fc309d33cd19e859c51b",
+        "i686-unknown-linux-gnu": "05d80840da179cd26bbc6e3e3973feec607471d800465e2b37614c225060cd2a",
+        "x86_64-unknown-linux-gnu": "aa4a96b010e0d4573e6a1fec230beaadaae6cdce2bb4befeee7b1c081ee9ef8c",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.49.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.49.0.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "aa5ad197dd505fe98f0b1e3e2e8a80c7",
+        "aarch64-unknown-linux-musl": "41773b5054c9a2c8ed15f56cd12a2c94",
+        "arm-unknown-linux-gnueabi": "52c8b4fb08cc4e09018caaefa414524c",
+        "arm-unknown-linux-gnueabihf": "61c7c0396d24333c75680e6a563c03ea",
+        "armv5te-unknown-linux-gnueabi": "376fffedb9a6ccfffa9ca1c78582c28c",
+        "armv5te-unknown-linux-musleabi": "a1681ada8e688a2e8c2894d21a9269b5",
+        "armv7-unknown-linux-gnueabihf": "22f4a98b1233676878a30c29c3228a0f",
+        "armv7-unknown-linux-musleabihf": "0a61739ee81f4bf5171ff4fbfee0e421",
+        "i686-unknown-linux-gnu": "3f0e4a580ee86118b6004e2ce2b19d93",
+        "mips-unknown-linux-gnu": "1fe2c11cddfd244697e95e43477fb083",
+        "mipsel-unknown-linux-gnu": "41d55c2ce1df4d68c1a63f694549a47d",
+        "powerpc-unknown-linux-gnu": "09cba093b9e6ab726b4e80a4e70e740a",
+        "x86_64-unknown-linux-gnu": "e69b1191bc7dcb89390f78f5135a92e4",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "c58bd4f0738ff662f70e35c19bfa6b8eb12ad54b0fbdce32ee3e50186c04a969",
+        "aarch64-unknown-linux-musl": "bc5501347598f48f55ba23011602a8fc1fe156c23c1c7b4d449c84eddd64d4ba",
+        "arm-unknown-linux-gnueabi": "a199df5c842e2fcb140836a0e3457fd8a1fe4c9a6d0f61bfab3e185fba7f0374",
+        "arm-unknown-linux-gnueabihf": "6d3449a346fa4c995bdd7281906fc754d01bd2937d4df0428127c74c75137c03",
+        "armv5te-unknown-linux-gnueabi": "e3e26fbe9a059af61549c937cfbd2e0f856434e966d7388a7149926f4fa59f22",
+        "armv5te-unknown-linux-musleabi": "5362a9def63b34f502ced91f776d3a353dd222cbc901c26c50994d3206487ad9",
+        "armv7-unknown-linux-gnueabihf": "1e13e84e3d0f8dfea6189f912233a2bd8cf9b07fd58ab25780f5c4f9cb4a0341",
+        "armv7-unknown-linux-musleabihf": "8a9ef1f5e7be994169df064d92384306794e2a0acbe8d22dd7a3dd3b476b398d",
+        "i686-unknown-linux-gnu": "86676315c04751e5b8e2f3a92150fca56b32228b545a1a7977731b4b2c1424b7",
+        "mips-unknown-linux-gnu": "334c00747588f509d53248f25f374d68bc722cbe4717245d884c7ee42dc1e32d",
+        "mipsel-unknown-linux-gnu": "038bda5ad5847dc50ea02c095dacdb0df777063b7109c371725d0676f7c6bff2",
+        "powerpc-unknown-linux-gnu": "352c7970e30acfdead43aee1659cb4e854adf7e2c9df11c4781cdd9edf1b8e79",
+        "x86_64-unknown-linux-gnu": "f0d2c2d509c29ea9f7c24bb5a885321030281631e0bde0714e5cf881184d57e2",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "72f315016cae0919fb0cc6b60b7c621f",
+        "arm-unknown-linux-gnueabi": "3297306a634d44affe79ae91373fa992",
+        "arm-unknown-linux-gnueabihf": "47aa1e8dcf86dbcad05bbae9a8f0185d",
+        "armv7-unknown-linux-gnueabihf": "f6c06bb84233524a8c00f059a5ace103",
+        "i686-unknown-linux-gnu": "1c5dc457c6a1f79b6220ab49252e56a1",
+        "x86_64-unknown-linux-gnu": "9e3e0fd2621bd6914eb885a7e8e94938",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "b72699cdf74c03ccc0aabab937a69807f2ceb5861f3508593e1c222190c4efc7",
+        "arm-unknown-linux-gnueabi": "d8d66a2fce6c326a002f1f27a8530e40904b5466ccceea3846518df3483b5fa6",
+        "arm-unknown-linux-gnueabihf": "1513631089cef540bd11df0d6cea914748d6f9f6da3f2c090ea51f951ce0608a",
+        "armv7-unknown-linux-gnueabihf": "7a8d0bb46599a254ddc1fcb05b56f63bf70f2a0687c5f770cd38a760fb091bd4",
+        "i686-unknown-linux-gnu": "3730540a123d22c4b7c26b4247b5c4b1ff4258ec9dea7804a536ad0e6bf00cb7",
+        "x86_64-unknown-linux-gnu": "42300556b987934e5e4677972c1dfc57eb07731dc62fa9f4f561935a1c84ed0e",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"
+
+require rust-bin-cross.inc


### PR DESCRIPTION
This commit adds the 
* [1.47.0](https://blog.rust-lang.org/2020/10/08/Rust-1.47.html)
* [1.48.0](https://blog.rust-lang.org/2020/11/19/Rust-1.48.html)
* [1.49.0](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html)

release of the rust language to this repo