### PR TITLE
Rust 1.53.0 and 1.54.0

### DIFF
--- a/recipes-devtools/rust/cargo-bin-cross_1.53.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.53.0.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20210617
+# This corresponds to rust release 1.53.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "11d53f0dc2bd84869e2498e8e258d4a2",
+        "arm-unknown-linux-gnueabi": "dd9667540e501a4b6a1b8862676232a0",
+        "arm-unknown-linux-gnueabihf": "51332e65cd38d7993c675bbbdf56ea42",
+        "armv7-unknown-linux-gnueabihf": "deb15137be9f2eb2256f5317032d699e",
+        "i686-unknown-linux-gnu": "2ed04273af4b1909475a7f8c91ee5275",
+        "x86_64-unknown-linux-gnu": "585191fa61dcaaf23ae734736c781339",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "7c35c086e294af3ae82df5609c6833a36bd8e6634e8ecca18f863829cfe80ca7",
+        "arm-unknown-linux-gnueabi": "56df4591b0051c7957f757a60e8978a07c6999ff86c837a8e4b43ceb9db50557",
+        "arm-unknown-linux-gnueabihf": "6b294d369278af80bea2cc6a01211e07dd62c21744b5f748216695cad5af5915",
+        "armv7-unknown-linux-gnueabihf": "7efd9decad862086014506c502fb5f21524e2c4bedf4b422212ee5dc64802126",
+        "i686-unknown-linux-gnu": "8ab2174a813b00573c0aa3cdc13b1b56931400fe95459e50855de4033f3e9e09",
+        "x86_64-unknown-linux-gnu": "e79d9d0b03cb331428ef3cfc4cbe60ded9f90708a7dd1714d974dab9a03ee7b3",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2021-06-17/cargo-1.53.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2021-06-17/cargo-1.53.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2021-06-17/cargo-1.53.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2021-06-17/cargo-1.53.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2021-06-17/cargo-1.53.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2021-06-17/cargo-1.53.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.53.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.54.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.54.0.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20210729
+# This corresponds to rust release 1.54.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "17497e670cd6ae9c7b1faa230520fd96",
+        "arm-unknown-linux-gnueabi": "8186181f9c484a727b9c580f30a1bb0e",
+        "arm-unknown-linux-gnueabihf": "7cfbf7afbc6e570e1ba65249ea144d16",
+        "armv7-unknown-linux-gnueabihf": "9c83302dda598742be34f82d54ad3bb2",
+        "i686-unknown-linux-gnu": "b6eaab7a3dd8346f90d7f8bdaea7a058",
+        "x86_64-unknown-linux-gnu": "62e7bfcdfd24ed9b5c2ab1edefbd8036",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "d54d0bde0014e73a9c6943665bd236e5596c86d58869bc758aa6c24a9ad53061",
+        "arm-unknown-linux-gnueabi": "5d832cc1688021d236086a67dde6485af5c0790cad641ad992c75f95f07cc3f1",
+        "arm-unknown-linux-gnueabihf": "73c6d9448e6515f45921ec0f0aacf92c0f3d68b2445d1eca4ca1cfefc05dbf13",
+        "armv7-unknown-linux-gnueabihf": "57bf3e6c10ecbcdb97b5ee913eae8537ad4ff9fc476a303d0da9e350d1495c97",
+        "i686-unknown-linux-gnu": "ae8414d0d3c740a9c42967e22452e5f8f6677e7c94b91c33afee468f91d978f4",
+        "x86_64-unknown-linux-gnu": "8c4f404e6fd3e26a535230d1d47d162d0e4a51a0ff82025ae526b5121bdbf6ad",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2021-07-29/cargo-1.54.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2021-07-29/cargo-1.54.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2021-07-29/cargo-1.54.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2021-07-29/cargo-1.54.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2021-07-29/cargo-1.54.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2021-07-29/cargo-1.54.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.54.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.53.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.53.0.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "07b6c1721833d3d83fcd5429b01a79f5",
+        "aarch64-unknown-linux-musl": "d9c9343f304a55763270443896e88004",
+        "arm-unknown-linux-gnueabi": "ace0ba159f3a810f3b13ff32354a369c",
+        "arm-unknown-linux-gnueabihf": "2fcbff07a06174bfe4b31eeeb330b0c5",
+        "armv5te-unknown-linux-gnueabi": "79da312104a6576884a650f6d7a82b58",
+        "armv5te-unknown-linux-musleabi": "c82b16e892751038545b7b4c55574f64",
+        "armv7-unknown-linux-gnueabihf": "63ab803b3e1a9a150b4cb15bc1ec0c4a",
+        "armv7-unknown-linux-musleabihf": "576ab0040a444c6378e6b6a3453debed",
+        "i686-unknown-linux-gnu": "4ba359ae6fc6edfce0a21be0b1933b22",
+        "mips-unknown-linux-gnu": "5f401f804827e0e0b70e26d189340e26",
+        "mipsel-unknown-linux-gnu": "2b46ba46c26040245f26eb862e4b44a6",
+        "powerpc-unknown-linux-gnu": "ddbe7328efec9d26636ef1b60011c4fa",
+        "x86_64-unknown-linux-gnu": "72f8d5515f8286bcc700f7ada8212ff7",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "9e5c09d14fec5609bfd042299900f20a44c52d53c64e76e184faadf67d07590d",
+        "aarch64-unknown-linux-musl": "7501cc0787a63e550f9918dc5d23ee9fa9f3f3162088b33213694be2d6e2aa32",
+        "arm-unknown-linux-gnueabi": "71496c8c6e723099ee9b1f119ac0e63527e5bb265226557ccd8a6c0338ce1321",
+        "arm-unknown-linux-gnueabihf": "c46c38d4b61776f9712d7331b7a6dc206a2a18fa55430564a647d5be6f3b3c63",
+        "armv5te-unknown-linux-gnueabi": "46a6a7f3df289a880c77c63d2bbaf048f52b1154a2fca64eae1f5e7aad480f2d",
+        "armv5te-unknown-linux-musleabi": "aa342256bbd4fe3ae7e09e6d582b044e1ba74047565f7b79973e12b76d701b2b",
+        "armv7-unknown-linux-gnueabihf": "10d29bceef74016989d4b77c614d4c953b0a9333aac975558f4a0ecc643438d9",
+        "armv7-unknown-linux-musleabihf": "da622a4c588ec1da4c7f1d6d958eb33f38b28107ba426b3f0393d81a2fc6b7f5",
+        "i686-unknown-linux-gnu": "c1a9877f301b64655cff671029bdeab3106a17715a6cb9bbfc9f4200ce33c065",
+        "mips-unknown-linux-gnu": "c8aaacc2208e9b0137dadb48dd690351d62b5efc2d8654e8cb3990f292a1ec37",
+        "mipsel-unknown-linux-gnu": "42574203bba6ad848b0aa65167d83a41a07320dc35b5e5c92ef8a740a7de273d",
+        "powerpc-unknown-linux-gnu": "0c7de1a87b38e3f8a335c9cb4a6f6a7421834e7e3162b0b7a9fa6d8ac267bb0a",
+        "x86_64-unknown-linux-gnu": "b3428b9ffd5a8f8f13506eedf2fc865665a53894408f0b64314686e8a08d06b2",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "c0ae7b97ebe3df4fff24ddd8969b7b63",
+        "arm-unknown-linux-gnueabi": "a5efde3876dc1645f18f29cb40088c71",
+        "arm-unknown-linux-gnueabihf": "f670f92a0398cc51ef67262d4e117a16",
+        "armv7-unknown-linux-gnueabihf": "f08981f8471c4cab365a48c69cf927b3",
+        "i686-unknown-linux-gnu": "a70cdb94189cc239549dfd1bdd029fad",
+        "x86_64-unknown-linux-gnu": "8284ecc16dd7844011fa86f23fa6415e",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "a54267708a1e80bab2c0a919284b9387f4b70ca61a96dce7544b2c8001adc5dd",
+        "arm-unknown-linux-gnueabi": "170ddbcd6ce4f8e121cf4eb52197a269ab489746ac14ec65eb029fd9185d6a9c",
+        "arm-unknown-linux-gnueabihf": "0316b20376f249a4a869f91b73f4d7b024856bb808ce5fe2c046892c5343d0ae",
+        "armv7-unknown-linux-gnueabihf": "a83cb786a965cbea9a7811b490c0e7eb5e4f2b916ef8c390521ac942a98fc196",
+        "i686-unknown-linux-gnu": "a3dff5684af2e168fcf3408a18a370b615861b953083d1592036c191d3798043",
+        "x86_64-unknown-linux-gnu": "c2c24b41602a589886f87276d4d46e42efddbad820917dc4dcbf6625cdf9ff52",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.54.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.54.0.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "4461b2f3ba9dbd2173c112b0afadb6ce",
+        "aarch64-unknown-linux-musl": "c87e1020d84c5f919d95022145b8acdb",
+        "arm-unknown-linux-gnueabi": "6f0a0b0274b82e5655954213c6d59817",
+        "arm-unknown-linux-gnueabihf": "0d2e6a462575dfe4e7af625676601e9f",
+        "armv5te-unknown-linux-gnueabi": "12c27eacb678fe70692e5424001b890f",
+        "armv5te-unknown-linux-musleabi": "778ab6900fd3fd9e96de8e8696e1890a",
+        "armv7-unknown-linux-gnueabihf": "24dd96e278fcb28f012e1be501db16e3",
+        "armv7-unknown-linux-musleabihf": "779bc06bbbe907a68eed39cf6bf91363",
+        "i686-unknown-linux-gnu": "35291926a33c3ae24edefde2cb1fc2be",
+        "mips-unknown-linux-gnu": "92b5d2aaffa656683dd724a50368eecc",
+        "mipsel-unknown-linux-gnu": "7c2a6669d16e4a15398bdcd86980aaad",
+        "powerpc-unknown-linux-gnu": "d35337be941de8dc440fa7fd1202f209",
+        "x86_64-unknown-linux-gnu": "c190b23f6521886297f594948498cb69",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "2d90cd90734a2d057b2a4eeee36a72d96569fb5fff0ac1e22eeb5fab93e66848",
+        "aarch64-unknown-linux-musl": "4c689f32444afa8faef2f7eb896b59f76827e9950f795988d626c9e4552e3d4b",
+        "arm-unknown-linux-gnueabi": "39ea90c1646448a8f695d9a60c581f4aec6883fa4de60e594c7b50047d5c3007",
+        "arm-unknown-linux-gnueabihf": "4e60c89d6397b4b3488107987896a414afd2737ba4c71002c0c41f9cdc189287",
+        "armv5te-unknown-linux-gnueabi": "ac989bbd0518832008a5fe501a5262d2e833c899995b77159f03cd8e4ee79aff",
+        "armv5te-unknown-linux-musleabi": "840a5c1250455aecb0d5967ef073fbfa3319bddc50557e350a4879b5e48f026c",
+        "armv7-unknown-linux-gnueabihf": "d0b6021f4235d2b1c5f48a61c56a4ffe9c49e85ce141e2f26a11e4cb5f1b9671",
+        "armv7-unknown-linux-musleabihf": "8c072f8ff1db0c249d88fda254418488ead4aa9b870047d1673a4a8e981aed6e",
+        "i686-unknown-linux-gnu": "f3ac7342c7231b2c5f2f8ec8980e338db1af07b779ca01b12f43df88d10bf79b",
+        "mips-unknown-linux-gnu": "22a01d615bae64219fd6abd7724a3b2e0eaa0161be8a175019c2df28a2992d8b",
+        "mipsel-unknown-linux-gnu": "b11cf8465c97cf178fcac48611180e14b53a88ff2da3602ab02889cc4df745f7",
+        "powerpc-unknown-linux-gnu": "8804b51911cd78689f72e8e26298931dad1c087a83ba4c10e955d7cc67f3543f",
+        "x86_64-unknown-linux-gnu": "487c51ac97e7f7deceae904b70e9bb031574dbeefe07b39b24e3fb00740962eb",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "e5f9faa374ec5e4602fa279b3dc4292d",
+        "arm-unknown-linux-gnueabi": "c33ce123dbed88e65d247156667b2b3c",
+        "arm-unknown-linux-gnueabihf": "a29ab77ed0aa5c293d57537d391940b9",
+        "armv7-unknown-linux-gnueabihf": "499fa7b8ae46c5cb32517f44c0eb8419",
+        "i686-unknown-linux-gnu": "59dbbd0b7d8c660051a77f21504a546e",
+        "x86_64-unknown-linux-gnu": "60d6233a33e5b11659dfa5ac91f6cdf0",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "595e8db56e68247ee3caf29f6a3d3c72d7955ed45f1291e7e596d63923427a86",
+        "arm-unknown-linux-gnueabi": "8717bb046e9d017efbd0dbd89482d8779dd334f78ae2fd3e3d7164f951bcb019",
+        "arm-unknown-linux-gnueabihf": "df05932eb41f5f706ad04a4f7283ac87b3914860863fdbdfca45c3cb2f1e03f2",
+        "armv7-unknown-linux-gnueabihf": "445ed0a100887ad7e3299a0dc21c1f0a45d9e3048089f0ef0c645da92ed70e45",
+        "i686-unknown-linux-gnu": "b0b102cd5a3b7218a3a0fc24517ad274597afee3aa86a6b62e9315366d9c2745",
+        "x86_64-unknown-linux-gnu": "cd4c1c5db3b8ca3f76fac42d209e83640794eb8c2bbfb71b71e5f93b584d159c",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"
+
+require rust-bin-cross.inc


### PR DESCRIPTION
Generated via `build-new-version.sh`.