### PR TITLE
Added specified nightly toolchain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ This will create two new recipes:
  release of rust itself (using the published channel data consumed by other
  tools like rustup).
 
+For latest nightly version:
+
+    ./build-new-version.sh nightly
+    
+For specified nightly version:
+    
+    ./build-new-version.sh nightly 2019-07-08
+    
+
 ## Copyright
 
 ```

--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -294,7 +294,16 @@ EOF
     }
     return get_by_triple(URLS, triple)
 
-DEPENDS += "rust-bin-cross-\${TARGET_ARCH} (= ${TARGET_VERSION}-${NIGHTLY_DATE})"
+EOF
+
+    if is_nightly; then
+        echo >> "$CARGO_BIN_RECIPE" "DEPENDS += \"rust-bin-cross-\${TARGET_ARCH} (= ${TARGET_VERSION}-${NIGHTLY_DATE})\""
+    else
+        echo >> "$CARGO_BIN_RECIPE" "DEPENDS += \"rust-bin-cross-\${TARGET_ARCH} (= ${TARGET_VERSION})\""
+    fi
+
+    cat <<EOF >>${CARGO_BIN_RECIPE}
+
 LIC_FILES_CHKSUM = "\\
     file://LICENSE-APACHE;md5=${CARGO_APACHE_EXPECTED} \\
     file://LICENSE-MIT;md5=${CARGO_MIT_EXPECTED} \\

--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -100,7 +100,7 @@ cargo_filename() {
 }
 
 download_files() {
- if [ x"$TARGET_VERSION" == x"nightly" -a "$NIGHTLY_DATE" ]; then
+    if [ x"$TARGET_VERSION" == x"nightly" -a "$NIGHTLY_DATE" ]; then
         download "https://static.rust-lang.org/dist/$NIGHTLY_DATE/$CHANNEL_FILE"
     else
         download "https://static.rust-lang.org/dist/$CHANNEL_FILE"

--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -47,6 +47,14 @@ RUSTC_TRIPLES=(
     x86_64-unknown-linux-gnu
 )
 
+is_nightly() {
+    if [ x"$TARGET_VERSION" == x"nightly" -a "$NIGHTLY_DATE" ]; then
+        true
+    else
+        false
+    fi
+}
+
 download() {
     echo "download $@"
     curl --fail -# -O $@
@@ -55,7 +63,7 @@ download() {
 dlfile() {
     component="$1"
     triple="$2"
-    if [ x"$TARGET_VERSION" == x"nightly" -a "$NIGHTLY_DATE" ]; then
+    if is_nightly; then
         download "https://static.rust-lang.org/dist/$NIGHTLY_DATE/$component-$TARGET_VERSION-$triple.tar.gz"
     else
         download "https://static.rust-lang.org/dist/$component-$TARGET_VERSION-$triple.tar.gz"
@@ -100,7 +108,7 @@ cargo_filename() {
 }
 
 download_files() {
-    if [ x"$TARGET_VERSION" == x"nightly" -a "$NIGHTLY_DATE" ]; then
+    if is_nightly; then
         download "https://static.rust-lang.org/dist/$NIGHTLY_DATE/$CHANNEL_FILE"
     else
         download "https://static.rust-lang.org/dist/$CHANNEL_FILE"

--- a/recipes-devtools/rust/cargo-bin-cross.inc
+++ b/recipes-devtools/rust/cargo-bin-cross.inc
@@ -31,7 +31,13 @@ do_install[depends] += "virtual/fakeroot-native:do_populate_sysroot"
 
 python () {
     pv = d.getVar("PV", True)
-    pv_uri = pv[0:4] + '-' + pv[4:6] + '-' + pv[6:8]
+
+    # only specified nightly needs another branch
+    nightly = pv.startswith("nightly-")
+
+    if nightly:
+        pv = "nightly"
+
     target = d.getVar("CARGO_HOST_TARGET", True)
     cargo_uri = ("%s;md5sum=%s;sha256sum=%s;downloadname=%s" %
                  (cargo_url(target), cargo_md5(target), cargo_sha256(target),

--- a/recipes-devtools/rust/rust-bin-cross.inc
+++ b/recipes-devtools/rust/rust-bin-cross.inc
@@ -20,7 +20,16 @@ RUST_BUILD_TARGET = "${@rust_target(d, 'BUILD')}"
 RUST_TARGET_TARGET = "${@rust_target(d, 'TARGET')}"
 RUST_ALL_TARGETS = "${RUST_BUILD_TARGET} ${RUST_TARGET_TARGET} ${EXTRA_RUST_TARGETS}"
 
-S = "${WORKDIR}/rustc-${PV}-${RUST_BUILD_TARGET}"
+def get_s(d):
+    pv = d.getVar("PV", True)
+    nightly = pv.startswith("nightly-")
+
+    if nightly:
+        return "${WORKDIR}/rustc-nightly-${RUST_BUILD_TARGET}"
+    else:
+        return "${WORKDIR}/rustc-${PV}-${RUST_BUILD_TARGET}"
+  
+S = "${@get_s(d)}"
 
 # Relocating WORKDIR doesn't matter to installer
 S[vardepsexclude] += "WORKDIR"
@@ -55,12 +64,27 @@ do_install[depends] += "virtual/fakeroot-native:do_populate_sysroot"
 
 python () {
     pv = d.getVar("PV", True)
+    nightly = pv.startswith("nightly-")
+
+    if nightly:
+        pv = pv.partition("-")[2]
+        target_version = "nightly"
+
     base_uri = d.getVar("RUST_BASE_URI", True)
     targets = d.getVar("RUST_ALL_TARGETS", True).split()
     build_target = d.getVar("RUST_BUILD_TARGET", True)
-    rustc_src_uri = ("%s/dist/rustc-%s-%s.tar.gz;md5sum=%s;sha256sum=%s" %
+    if nightly:
+        rustc_src_uri = ("%s/dist/%s/rustc-%s-%s.tar.gz;md5sum=%s;sha256sum=%s" %
+                     (base_uri, pv, target_version, build_target, rustc_md5(build_target), rustc_sha256(build_target)))
+    else:
+        rustc_src_uri = ("%s/dist/rustc-%s-%s.tar.gz;md5sum=%s;sha256sum=%s" %
                      (base_uri, pv, build_target, rustc_md5(build_target), rustc_sha256(build_target)))
-    std_src_uris = ["%s/dist/rust-std-${PV}-%s.tar.gz;md5sum=%s;sha256sum=%s;subdir=rust-std" %
+
+    if nightly:
+        std_src_uris = ["%s/dist/%s/rust-std-%s-%s.tar.gz;md5sum=%s;sha256sum=%s;subdir=rust-std" %
+                    (base_uri, pv, target_version, target, rust_std_md5(target), rust_std_sha256(target)) for target in targets]
+    else:
+        std_src_uris = ["%s/dist/rust-std-${PV}-%s.tar.gz;md5sum=%s;sha256sum=%s;subdir=rust-std" %
                     (base_uri, target, rust_std_md5(target), rust_std_sha256(target)) for target in targets]
     src_uri = d.getVar("SRC_URI", True).split()
     d.setVar("SRC_URI", ' '.join(src_uri + [rustc_src_uri] + std_src_uris))


### PR DESCRIPTION
1. `build-new-version.sh`: added support to download specified nightly version
2. fix `cargo-bin-cross.inc` and `rust-bin-cross.inc` to support nightly version
3. added nightly 2019-07-08 version recipe ( [optee](https://github.com/apache/incubator-teaclave-trustzone-sdk) requires specified nightly version )

Question: How can I specify a toolchain only to certain recipe? PREFERRED_VERSION only support selection of toolchain globally.