### PR TITLE
Include .rlib files in -dev package

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -40,6 +40,8 @@ WRAPPER_DIR = "${WORKDIR}/wrappers"
 # Set the Cargo manifest path to the typical location
 CARGO_MANIFEST_PATH ?= "${S}/Cargo.toml"
 
+FILES:${PN}-dev += "${libdir}/*.rlib"
+
 CARGO_BUILD_FLAGS = "\
     --verbose \
     --manifest-path ${CARGO_MANIFEST_PATH} \


### PR DESCRIPTION
[#119](https://github.com/rust-embedded/meta-rust-bin/pull/119) added the feature to install examples and libraries by default if they exist. An unintended consequence of that though was breaking existing builds when a .rlib file was installed but then not included in the FILES directive.

To keep parity with meta-rust we'll start packaging .rlib files in the -dbg package.