### PR TITLE
Add kirkstone to compatibility layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ LICENSE = "MIT"
 
 inherit cargo
 
-SRC_URI = "gitsm://github.com/rust-embedded/gpio-utils.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/rust-embedded/gpio-utils.git;protocol=https;branch=master"
 SRCREV="02b0658cd7e13e46f6b1a5de3fd9655711749759"
 S = "${WORKDIR}/git"
 LIC_FILES_CHKSUM = "file://LICENSE-MIT;md5=935a9b2a57ae70704d8125b9c0e39059"

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ An OpenEmebdded/Yocto layer providing pre-built toolchains for the
 
 <!-- toc -->
 
-- [Basic Example](#basic-example)
-- [Features](#features)
-- [Advanced Features](#advanced-features)
-  * [Specifying Cargo Features](#specifying-cargo-features)
-  * [Using Components Individually](#using-components-individually)
-- [Pre-built vs. Compiled](#pre-built-vs-compiled)
-- [Copyright](#copyright)
+- [meta-rust-bin](#meta-rust-bin)
+  - [Basic Example](#basic-example)
+  - [Features](#features)
+  - [Advanced Features](#advanced-features)
+    - [Specifying Cargo Features](#specifying-cargo-features)
+    - [Using Components Individually](#using-components-individually)
+  - [Pre-built vs. Compiled](#pre-built-vs-compiled)
+  - [Adding Support for New Versions](#adding-support-for-new-versions)
+  - [Copyright](#copyright)
 
 <!-- tocstop -->
 
@@ -20,19 +22,19 @@ An OpenEmebdded/Yocto layer providing pre-built toolchains for the
 ## Basic Example
 
 A basic class for cargo-based executables is provided. The following is a
-simple recipe that builds the [gpio-utils](https://github.com/rust-embedded/gpio-utils)
-crate from a branch tagged with the version `${PV}`:
+simple recipe called gpio_utils.bb that builds the [gpio-utils](https://github.com/rust-embedded/gpio-utils)
+crate from branch master.
 
 ```bitbake
-inherit cargo
-
 SUMMARY = "GPIO Utilities"
 HOMEPAGE = "git://github.com/rust-embedded/gpio-utils"
 LICENSE = "MIT"
 
-SRC_URI = "https://github.com/rust-embedded/gpio-utils.git;tag=${PV}"
-S = "${WORKDIR}/git"
+inherit cargo
 
+SRC_URI = "gitsm://github.com/rust-embedded/gpio-utils.git;protocol=https;branch=master"
+SRCREV="02b0658cd7e13e46f6b1a5de3fd9655711749759"
+S = "${WORKDIR}/git"
 LIC_FILES_CHKSUM = "file://LICENSE-MIT;md5=935a9b2a57ae70704d8125b9c0e39059"
 ```
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,11 +1,11 @@
 # We have a conf and classes directory, append to BBPATH
-BBPATH .= ":${LAYERDIR}"
+BBPATH =. "${LAYERDIR}:"
 
 # We have a recipes directory, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "rust-bin-layer"
-BBFILE_PATTERN_rust-bin-layer := "^${LAYERDIR}/"
+BBFILE_PATTERN_rust-bin-layer = "^${LAYERDIR}/"
 BBFILE_PRIORITY_rust-bin-layer = "7"
 
 LICENSE_PATH += "${LAYERDIR}/files/common-licenses"
@@ -15,4 +15,5 @@ LAYERSERIES_COMPAT_rust-bin-layer = " \
     gatesgarth \
     hardknott \
     honister \
+    kirkstone \
 "

--- a/recipes-devtools/rust/cargo-bin-cross.inc
+++ b/recipes-devtools/rust/cargo-bin-cross.inc
@@ -11,7 +11,7 @@ PN = "cargo-bin-cross-${TARGET_ARCH}"
 CARGO_HOST_TARGET = "${@rust_target(d, 'HOST')}"
 
 SYSROOT_DIRS_NATIVE += "${prefix}"
-SYSROOT_DIRS_BLACKLIST += "\
+SYSROOT_DIRS_IGNORE += "\
     ${prefix}/share \
     ${prefix}/etc \
 "

--- a/recipes-devtools/rust/rust-bin-cross.inc
+++ b/recipes-devtools/rust/rust-bin-cross.inc
@@ -26,7 +26,7 @@ S = "${WORKDIR}/rustc-${PV}-${RUST_BUILD_TARGET}"
 S[vardepsexclude] += "WORKDIR"
 
 SYSROOT_DIRS_NATIVE += "${prefix}"
-SYSROOT_DIRS_BLACKLIST += "\
+SYSROOT_DIRS_IGNORE += "\
     ${prefix}/share \
     ${prefix}/etc \
 "


### PR DESCRIPTION
Updating the meta-rust-bin to support the kirkstone compatibility layer. Updated the README.md example recipe.

[Yocto Kirkstone Migration SYSROOT_DIRS_BLACKLIST to SYSROOT_DIRS_IGNORE](https://docs.yoctoproject.org/dev/migration-guides/migration-4.0.html)

There are changes included in this PR suggested by https://github.com/rust-embedded/meta-rust-bin/pull/111.