### PR TITLE
Add Rust 1.62.1, 1.63.0

### DIFF
--- a/recipes-devtools/rust/cargo-bin-cross_1.62.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.62.1.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20220719
+# This corresponds to rust release 1.62.1
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "66218b44e945612d97d7235167050360",
+        "arm-unknown-linux-gnueabi": "640290f6360e282f7cd0efc8de178385",
+        "arm-unknown-linux-gnueabihf": "e974560e51d16eb81b0a424ef40da8ef",
+        "armv7-unknown-linux-gnueabihf": "efc89902e484a92cc6f80a970d204963",
+        "i686-unknown-linux-gnu": "319a5c36ad625adb2572c97f55c8855e",
+        "x86_64-unknown-linux-gnu": "abacd6e115de01f104501f00224eae09",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "5c14e1bdfe37cf004cc7abac1f4498c36c5c7675849125ef4c48e1589c6641f7",
+        "arm-unknown-linux-gnueabi": "426fbb10ee8409cce45fe24a3b4b43b8fa56f9209440791901ece396879f6db8",
+        "arm-unknown-linux-gnueabihf": "aece937cf4665c3277a7d444e07d4dca8a47cb5a7179a2b3e79b05914193c5e9",
+        "armv7-unknown-linux-gnueabihf": "d41b71a66786fb2edb915230a2862a949b6bbbc7a84b08c74a9495fb8036a867",
+        "i686-unknown-linux-gnu": "e6f337277526f9cb1243485883a388ed6e3b33ba6360fe159d0209bdf25e4562",
+        "x86_64-unknown-linux-gnu": "7a471270fe18dfe231693178c169b279c0747ae179fd755729eefd8c6052f595",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2022-07-19/cargo-1.62.1-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2022-07-19/cargo-1.62.1-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2022-07-19/cargo-1.62.1-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2022-07-19/cargo-1.62.1-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2022-07-19/cargo-1.62.1-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2022-07-19/cargo-1.62.1-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.62.1)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.63.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.63.0.bb
@@ -1,0 +1,50 @@
+
+# Recipe for cargo 20220811
+# This corresponds to rust release 1.63.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "ba1acf26796d2b9be51c5d47f123aef5",
+        "arm-unknown-linux-gnueabi": "1e13f968108b187fec71ab62e0938059",
+        "arm-unknown-linux-gnueabihf": "83c03465c9c02502f9230bacc40ed16a",
+        "armv7-unknown-linux-gnueabihf": "aa496f31b4cbff223662c8d1f46cbf44",
+        "i686-unknown-linux-gnu": "d0ffab8f7dd97733ff149d10b4099fbf",
+        "x86_64-unknown-linux-gnu": "f3f3e78598f7b8c51a9e47e8c19fb32f",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "4e359ffb5ef7cb69014d1c7c9a9ccdd2efa1220551f09f52aac16777eb75f01b",
+        "arm-unknown-linux-gnueabi": "09405d9c79c133f7be749f15f248e7a9eb96508123d9c6549f2c287d60208391",
+        "arm-unknown-linux-gnueabihf": "e07eb5f2ec8c913c4c06157de16cf15b2b392b3c0cdf79a5c00b3903f3d40b50",
+        "armv7-unknown-linux-gnueabihf": "aa3be47cb33e3ccd1a9ebf9f7dbc47780121fd5e88ae5dbdd4adc35ddb3a1f14",
+        "i686-unknown-linux-gnu": "8a157b8899797b3224742ad51e91f21f903f3523513b1a70ba78f60fc7f595ce",
+        "x86_64-unknown-linux-gnu": "43445b2131cefa466943ed4867876f5835fcb17243a18e1db1c8231417a1b27e",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2022-08-11/cargo-1.63.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2022-08-11/cargo-1.63.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2022-08-11/cargo-1.63.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2022-08-11/cargo-1.63.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2022-08-11/cargo-1.63.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2022-08-11/cargo-1.63.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.63.0)"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.62.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.62.1.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "1a27cb446b2792b9a3663611653bb7de",
+        "aarch64-unknown-linux-musl": "a15d3e8a3dd66a43f1a65d881426cc89",
+        "arm-unknown-linux-gnueabi": "5eb0a22df9352d22707b9e89842d0ea9",
+        "arm-unknown-linux-gnueabihf": "098c6a76f5881317fb981b307ba221e0",
+        "armv5te-unknown-linux-gnueabi": "b4ea4d71f1ca3c262b1d886941a9dd46",
+        "armv5te-unknown-linux-musleabi": "9d33bd13d38325da0e0fce0e21f3b0bc",
+        "armv7-unknown-linux-gnueabihf": "bf1d5575419429eae0427f9d68153842",
+        "armv7-unknown-linux-musleabihf": "232b90e5498b4d58d89af7d8be75d3b4",
+        "i686-unknown-linux-gnu": "d570b61de91491ede1c926adda42cef7",
+        "mips-unknown-linux-gnu": "8f6fa2b253c1d5c0836ebb086e88a609",
+        "mipsel-unknown-linux-gnu": "644664175ca40196f92af31e6b5c9abf",
+        "powerpc-unknown-linux-gnu": "d725dccafdcf91eb702cc75730beb758",
+        "x86_64-unknown-linux-gnu": "7e8c209615b1c65c4f710c2255010eac",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "6af6bac7a3ae1b2e1b9153d5d0bed124122daf8e6a8e90440701cb199c2c95d2",
+        "aarch64-unknown-linux-musl": "ef305007ff13cefabb08a6bc69751fdc25a453fa54aaf535cfda21d8ad86426a",
+        "arm-unknown-linux-gnueabi": "4d5a75ab5b254ad78635174b4b0fd09b22ff6d3116b1a4a799376f544fb0f268",
+        "arm-unknown-linux-gnueabihf": "dd0ca5a39cb5d7c02abdbe872fe9045607b8abd4920f2dc1750dcbaf7d2a4dfe",
+        "armv5te-unknown-linux-gnueabi": "1ac393901b778fa9bbde6394cf77941d1ded95cb35538009b657420a84458cc2",
+        "armv5te-unknown-linux-musleabi": "a2d3e10f4cb216abcdf22a3e6d9a68ed4f0ecfbbbb530962f43dd96e4d04f4a3",
+        "armv7-unknown-linux-gnueabihf": "13515c3ef9356511bd2b750e98761ca08503f148db871fe08036d4a619b6d37f",
+        "armv7-unknown-linux-musleabihf": "2a983f090160b3537faa18e3d852711ef757f30bd90eb53972a1f691efcd21c4",
+        "i686-unknown-linux-gnu": "22c07df648225e1a1cf23ad84668772e2ea072174537353b739fd80464e74ab5",
+        "mips-unknown-linux-gnu": "0586a7c4b225a0ae5cce29229dbf4ae96a99d855830d6d436d32437530a6c7a0",
+        "mipsel-unknown-linux-gnu": "2aee14fcc2e393eaee744c4ac158d2b9ad159f9982124b2cd4d5ebda23f1417d",
+        "powerpc-unknown-linux-gnu": "d409da640e9b46893d9d07fd493a1cddd622f399e945e2da9ce127ddf9f82b7f",
+        "x86_64-unknown-linux-gnu": "564e5afc7151826190f8b31ed839fc305469158967ffe907d4c6e712a281ff5f",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "d3e87582a7c0c75903de4d9b72ec3739",
+        "arm-unknown-linux-gnueabi": "f4fecd817ede238b729979ccb16c9dbf",
+        "arm-unknown-linux-gnueabihf": "4a2d2de678d0eb5dac6a881e740e5e9a",
+        "armv7-unknown-linux-gnueabihf": "ee4d6a45692387a7a0b61b94bc882c9b",
+        "i686-unknown-linux-gnu": "648afadeec12f8617ce54a89b6926126",
+        "x86_64-unknown-linux-gnu": "b0781405c138b25c47a9478190909500",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "7f61cee6f69fb6895cef5e5d077504ca69dbf35535defd5182b7e60582b7f1d0",
+        "arm-unknown-linux-gnueabi": "ef84833d3ba5f4ebfb277a46db377f3d3c18a28fcbac9379fe79967c896cafb9",
+        "arm-unknown-linux-gnueabihf": "f0ff294417fa1d2583920cc203812e911c3e7295ef1023df0a794d71591bfc96",
+        "armv7-unknown-linux-gnueabihf": "80f26a4dbd072e65ffe500dcb3ffb352fb54e505b957511ad1eac9ad59af028f",
+        "i686-unknown-linux-gnu": "3b1328dccbe32ef476e5f3429f81b90e243bfbce717c9d00bda35e18d4c10c54",
+        "x86_64-unknown-linux-gnu": "4066d5f897864f88dbe55fdc190881272132d3acf031f6aa29e1b19a3b589c9c",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.63.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.63.0.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "1cb6f3e6054298c946993029a26f610f",
+        "aarch64-unknown-linux-musl": "ad0293c26d615e85ceff8468b32ceb17",
+        "arm-unknown-linux-gnueabi": "423b683727b8ebecb9d3a893134a0c78",
+        "arm-unknown-linux-gnueabihf": "6caca9742e4377171201039a0b754145",
+        "armv5te-unknown-linux-gnueabi": "07d5e7d892cf028e221d3e420e4ec474",
+        "armv5te-unknown-linux-musleabi": "c1d055e5e05edf73363a132f1cf0c58e",
+        "armv7-unknown-linux-gnueabihf": "dc85de93030ce16c2ccfe602ee778164",
+        "armv7-unknown-linux-musleabihf": "773bd7a1c5a294fee0aeab5b2232c7bf",
+        "i686-unknown-linux-gnu": "748087a92606e191266500e87060baf4",
+        "mips-unknown-linux-gnu": "f98a0ba89adddf0471bc6e8153c8888d",
+        "mipsel-unknown-linux-gnu": "5c1083e09f134cddb29937dabb2d5665",
+        "powerpc-unknown-linux-gnu": "f6b8de0e7584aafc05592558c14dc920",
+        "x86_64-unknown-linux-gnu": "260c066bc19d6963296033d66a8b42cd",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "4afce4152945642fb4c1a7fa44ffe396f98ce094108ffe29b1833413e8eed49d",
+        "aarch64-unknown-linux-musl": "0f3d44e3432ed152d5ad9759741bcc8844386af3286beb6dc856323d7f56565c",
+        "arm-unknown-linux-gnueabi": "55e59d256f7b00681ac039c110cebba016f82acacd1f3bf8942cd76887d0f8a8",
+        "arm-unknown-linux-gnueabihf": "6cb1493e1b0bc981c59b2457d76e16f330b0543737cda969246b377e4520c45c",
+        "armv5te-unknown-linux-gnueabi": "cfb04fd59ba012538500da9e9ff5ef1cbf6940c1414cd71dd5a6225f798f1a90",
+        "armv5te-unknown-linux-musleabi": "b28460e19e127903f11baa562f91d665b8687c77d3ab5e9bdd5158f1060b4738",
+        "armv7-unknown-linux-gnueabihf": "998c9a1af2fce446f37b77d6400a32fb3097def293d2f73faedd0d0cafd42a33",
+        "armv7-unknown-linux-musleabihf": "d37ae049dca59b174db5b54a1c157b54c8cc49396699e135f5fad9d306568ac9",
+        "i686-unknown-linux-gnu": "5df51e9119d49addbf78ca6fbaf78a869f7aea46853a8fdfe339d543d0d88c3b",
+        "mips-unknown-linux-gnu": "0e235151b2f33a03a4717b2e9f3644a3d3ef502844545fea3645214403ac143a",
+        "mipsel-unknown-linux-gnu": "696c84c83cb22c3019ff18cdc21fc5206bc7e56d4f51c86e26dc4ebfaf952aa5",
+        "powerpc-unknown-linux-gnu": "460dbad0c90b35c3adda748d62efb568c8bb7703c8ce489a4da05c75c594a841",
+        "x86_64-unknown-linux-gnu": "4211c28e3359e915c116524aeb13a728dfd1e8889d1b01d32ed64b2995534eae",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "a61240fe855eee27ac96c6c04c7b7169",
+        "arm-unknown-linux-gnueabi": "eda67b58b320b67506d1104b1614f157",
+        "arm-unknown-linux-gnueabihf": "5cc9e950f58b8d24e72efd9842495e86",
+        "armv7-unknown-linux-gnueabihf": "d14aa97373754ba04b4276cf33c6de41",
+        "i686-unknown-linux-gnu": "06dac391e5114edd841be9c91f05956d",
+        "x86_64-unknown-linux-gnu": "35f1c900b44c2b3f20d1938f5610a84c",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "a4189dda06098813fb1e08861deae8993c809051c3c716b6aefe3793f5f0fb5e",
+        "arm-unknown-linux-gnueabi": "4c8f7000a1662e0bc2d1e5153d56784c2fafadfc0306d26dfd3e902c568b50b1",
+        "arm-unknown-linux-gnueabihf": "63eab3494123b67b7b0cccca5689e430ab0c62200c48b96892afc6cd0ebfa4e6",
+        "armv7-unknown-linux-gnueabihf": "0e0347051ba9530ccdba8fdafd394a52c4623fe4f9d1ee53f6f5d66f4fd2c25d",
+        "i686-unknown-linux-gnu": "4b7ec3ebbc32fd269775367b3dd800f53bec91ffcc33e7e1f6cd98f81bc4095f",
+        "x86_64-unknown-linux-gnu": "c5bb7656557bf6451b2c53b18b6d092814fcba922ff2ffa4f704a41d79595f2d",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=93a95682d51b4cb0a633a97046940ef0"
+
+require rust-bin-cross.inc


### PR DESCRIPTION
Contents created by running `build-new-version.sh`.