### PR TITLE
Add a note about BBMASK to avoid conflicts with poky rust recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,16 @@ Future:
     (provides space savings).
   * [ ] Total static linking using MUSL.
 
+### Use with Yocto Release 3.4 (honister) and Above
 
+Rust is included directly in `openmbedded-core` as of Yocto version 3.4. The
+included recipe builds Rust components from the sources. To use binaries from
+the `meta-rust-bin` layer instead, set `BBMASK` to exclude the package in your
+configuration:
+
+```bitbake
+BBMASK = "poky/meta/recipes-devtools/rust"
+```
 
 ## Advanced Features
 


### PR DESCRIPTION
Rust support was added to open embedded-core in the 3.4 honister release. This change just adds a note to the README file.