### PR TITLE
fix host and target linker problem

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -52,21 +52,7 @@ CARGO_BUILD_FLAGS = "\
 "
 
 create_cargo_config() {
-    if [ "${RUST_BUILD}" != "${RUST_TARGET}" ]; then
-        echo > ${CARGO_HOME}/config
-        echo "[target.${RUST_BUILD}]" >> ${CARGO_HOME}/config
-        echo "linker = '${WRAPPER_DIR}/linker-native-wrapper.sh'" >> ${CARGO_HOME}/config
-
-        echo >> ${CARGO_HOME}/config
-        echo "[target.${RUST_TARGET}]" >> ${CARGO_HOME}/config
-        echo "linker = '${WRAPPER_DIR}/linker-wrapper.sh'" >> ${CARGO_HOME}/config
-    else
-        echo > ${CARGO_HOME}/config
-        echo "[target.${RUST_TARGET}]" >> ${CARGO_HOME}/config
-        echo "linker = '${WRAPPER_DIR}/linker-wrapper.sh'" >> ${CARGO_HOME}/config
-    fi
-
-    echo >> ${CARGO_HOME}/config
+    echo > ${CARGO_HOME}/config
     echo "[build]" >> ${CARGO_HOME}/config
     echo "rustflags = ['-C', 'rpath']" >> ${CARGO_HOME}/config
 
@@ -116,8 +102,8 @@ cargo_do_compile() {
     export TARGET_CXX="${WRAPPER_DIR}/cxx-wrapper.sh"
     export CC="${WRAPPER_DIR}/cc-native-wrapper.sh"
     export CXX="${WRAPPER_DIR}/cxx-native-wrapper.sh"
-    export TARGET_LD="${WRAPPER_DIR}/ld-wrapper.sh"
-    export LD="${WRAPPER_DIR}/ld-native-wrapper.sh"
+    export TARGET_LD="${WRAPPER_DIR}/linker-wrapper.sh"
+    export LD="${WRAPPER_DIR}/linker-native-wrapper.sh"
     export PKG_CONFIG_ALLOW_CROSS="1"
     export LDFLAGS=""
     export RUSTFLAGS="${RUSTFLAGS}"
@@ -126,6 +112,14 @@ cargo_do_compile() {
     bbnote "which cargo:" `which cargo`
     bbnote "cargo --version" `cargo --version`
     bbnote cargo build ${CARGO_BUILD_FLAGS}
+
+    export __CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS="nightly"
+    export CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST="true"
+    export CARGO_TARGET_APPLIES_TO_HOST="false"
+    export CARGO_UNSTABLE_HOST_CONFIG="true"
+    export CARGO_HOST_LINKER="${WRAPPER_DIR}/linker-native-wrapper.sh"
+    export CARGO_TARGET_${@d.getVar('RUST_TARGET', True).upper().replace('-','_')}_LINKER="${WRAPPER_DIR}/linker-wrapper.sh"
+	
     cargo build ${CARGO_BUILD_FLAGS}
 }
 

--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -113,6 +113,19 @@ cargo_do_compile() {
     bbnote "cargo --version" `cargo --version`
     bbnote cargo build ${CARGO_BUILD_FLAGS}
 
+    # __CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS="nightly" is to allow
+    # using nighly features on stable releases, i.e features that are not
+    # yet considered stable.
+    #
+    # CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST="true" enables the nightly
+    # configuration option target-applies-to-host value to be set
+    #
+    # CARGO_TARGET_APPLIES_TO_HOST="false" is actually setting the value
+    # for this feature, which we disable, to make sure builds where target
+    # arch == host arch work correctly
+    #
+    # CARGO_UNSTABLE_HOST_CONFIG="true" enables the configuration option 
+    # CARGO_HOST_LINKER value to be set
     export __CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS="nightly"
     export CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST="true"
     export CARGO_TARGET_APPLIES_TO_HOST="false"


### PR DESCRIPTION
## Summary
I've read all the threads discussing the issue and I've ported the same concepts used in buildroot.

## Details

In particular it uses unstable flags to set different linkers for host and target, pointing respectively to `linker-native-wrapper.sh` and `linker-wrapper.sh`.

I've removed the linked section generation in the global toml file for consistency with buildroot and also to have linker settings near the unstable flag because part of the them are also unstable.

Without using these flags is impossible to compiler a normal rust application because right now almost all rust applications use dependencies with build scripts inside. These flags also enforce others correct behaviours for cross compilation.   

In the end using these flags should be safe, other people have already used  them; in case someone complains about that we can always revert the changes and find a better alternative.

## Added
- unstable flags to better support cross compilation

## Fixed
- typo in liker path

Closes #97