### PR TITLE
Add Rust 1.66.0 & 1.66.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dependencies as well as default compile and install steps.
 
 Currently supported:
 
-  * Rust 1.66.0 (and many older, stable versions)
+  * Rust 1.66.1 (and many older, stable versions)
   * x86 (32 and 64-bit), ARM (32 and 64-bit) build systems.
   * All Linux architectures that Rust itself supports (Multiple flavors of:
     x86, ARM, PPC, and MIPS)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dependencies as well as default compile and install steps.
 
 Currently supported:
 
-  * Rust 1.65.0 (and many older, stable versions)
+  * Rust 1.66.0 (and many older, stable versions)
   * x86 (32 and 64-bit), ARM (32 and 64-bit) build systems.
   * All Linux architectures that Rust itself supports (Multiple flavors of:
     x86, ARM, PPC, and MIPS)

--- a/recipes-devtools/rust/cargo-bin-cross_1.66.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.66.0.bb
@@ -1,0 +1,51 @@
+
+# Recipe for cargo 20221215
+# This corresponds to rust release 1.66.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "425feddfc90dffbfc08bd4c1e8b07eab",
+        "arm-unknown-linux-gnueabi": "9ee8847d5d9e4adea7a235202b1279ab",
+        "arm-unknown-linux-gnueabihf": "64036aef4171e39f2b294bad7fddcb3b",
+        "armv7-unknown-linux-gnueabihf": "072ddbb48b3dcf272cf27ce05079f388",
+        "i686-unknown-linux-gnu": "9a18be86d1b165dc0d2dfc414b849136",
+        "x86_64-unknown-linux-gnu": "7c00fe0f5670065e6ad1635c5e265852",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "87c32a5281a96abd04dda530e12f03c845a2057e072f14a4f6f90aa4425f337c",
+        "arm-unknown-linux-gnueabi": "2ddea83b2f00153532ef1f857159c227cd3f4267b7eeb4fdcb93e1fa9791561d",
+        "arm-unknown-linux-gnueabihf": "5f22f95c032d15cd1ffc953774a6ca0d0ab9eb30acb3bea81331bf81bd7ecec2",
+        "armv7-unknown-linux-gnueabihf": "aafe273079e3d5b35eafaa59dca1d566075f7c011fd114230ce612d30c63ed05",
+        "i686-unknown-linux-gnu": "52cfd43096ed88101752dab0d63d7651903fd0e10fb6db02a0f9a096dde9fe6b",
+        "x86_64-unknown-linux-gnu": "587080f377f7e259ab97fbf78cb0a5ef9094f3f333af25368d8d3346c192f13d",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2022-12-15/cargo-1.66.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2022-12-15/cargo-1.66.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2022-12-15/cargo-1.66.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2022-12-15/cargo-1.66.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2022-12-15/cargo-1.66.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2022-12-15/cargo-1.66.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.66.0)"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.66.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.66.1.bb
@@ -1,0 +1,51 @@
+
+# Recipe for cargo 20230110
+# This corresponds to rust release 1.66.1
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "5d16e84f27e443a77fdd97702fb5b4ed",
+        "arm-unknown-linux-gnueabi": "8135311bc9e21f2afc3a00c7430497f2",
+        "arm-unknown-linux-gnueabihf": "ca1d7f643f36ba8c52868d94320b8886",
+        "armv7-unknown-linux-gnueabihf": "1757d17b7c50206b2fda5935e5422924",
+        "i686-unknown-linux-gnu": "e588ac60ce136e332516b1a7f13bf9ea",
+        "x86_64-unknown-linux-gnu": "cc8b3642f14832f5b0c81ec9d42d2020",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "96a44a8ca403f66573d5a8a56610456ac8c0a075f32a6680f8ec4cfff27aa244",
+        "arm-unknown-linux-gnueabi": "267ef161d2248a4f37d168ec59b5e07168ed54f0d3c70f65315b85f4103adda7",
+        "arm-unknown-linux-gnueabihf": "8f96fe00ed1d795888530570b12d82feec2d1d01a764ce8815218c46970e436c",
+        "armv7-unknown-linux-gnueabihf": "4c8eb18c404e1d675822b8e6571b0965be91d33adbe682a171da6f5e3bf4de34",
+        "i686-unknown-linux-gnu": "432d9fcd0748fabe71ae69a6ccb4ec7a4659bb388e0160c55abbe9af83c77193",
+        "x86_64-unknown-linux-gnu": "7752e7c5cd12204fe852bcb2a67d7fa9ab037f26dd34ccc3b25253b4c223df19",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-01-10/cargo-1.66.1-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2023-01-10/cargo-1.66.1-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-01-10/cargo-1.66.1-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-01-10/cargo-1.66.1-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-01-10/cargo-1.66.1-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-01-10/cargo-1.66.1-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.66.1)"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.66.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.66.0.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "38657b331891c4a976a8842c9617051e",
+        "aarch64-unknown-linux-musl": "a35494801e84f3981a55d482c8ea7e15",
+        "arm-unknown-linux-gnueabi": "d308038faf6702f91425490652414971",
+        "arm-unknown-linux-gnueabihf": "f6687013cb7515471e9636e26951d1a8",
+        "armv5te-unknown-linux-gnueabi": "7a06fce089fee201a195baca880c42b7",
+        "armv5te-unknown-linux-musleabi": "129bb6388829f368aee14094f87aa906",
+        "armv7-unknown-linux-gnueabihf": "683a4d5967e382cdc07d27d56228c9ed",
+        "armv7-unknown-linux-musleabihf": "4b5e67936bdaa7ed0fd159b693ed1007",
+        "i686-unknown-linux-gnu": "0d2d21d2bfb222a4722aae6ef5147db6",
+        "mips-unknown-linux-gnu": "9f1cbbd81f364fb0cbffb242694ccee1",
+        "mipsel-unknown-linux-gnu": "1b97dffc9efe719774aa9c52552b8b03",
+        "powerpc-unknown-linux-gnu": "baf39f7a39b65bca835445f81ccc3db2",
+        "x86_64-unknown-linux-gnu": "e1df18014d62b5281fee762c8a3afce1",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "2518ec4539b3de01a47d26b737aa243eb515d2e512f1a2b3361699daa4acc7d6",
+        "aarch64-unknown-linux-musl": "c60dfac48548a03ca9b923b543044d6843e571f6939aed45969d1c22bbf2c53c",
+        "arm-unknown-linux-gnueabi": "5a60074176e10a7c194dca3a96e26222a8e66707b3f7c58dbad5a78187b1010a",
+        "arm-unknown-linux-gnueabihf": "8e89264e1cc891f069b1b9afd8e3aaf66883b295c57d60c8dece6d61f15e8cce",
+        "armv5te-unknown-linux-gnueabi": "e5b23bfbdf168e918f1cc13ebf149fcc011c5e6bf470677c2d66d04d5bf074da",
+        "armv5te-unknown-linux-musleabi": "26ba1c104ee67cc5d864d5cceb31bee5592d55005bb3945c20beb9fe6b7be185",
+        "armv7-unknown-linux-gnueabihf": "c88d163b38317d2e3d92925cbd5986a89a1f67b764435d805df84052705e0aad",
+        "armv7-unknown-linux-musleabihf": "06518d7fe1439352785147f0553e6e99f83b3366aab566cb9112381008157798",
+        "i686-unknown-linux-gnu": "4276bbe18b7570ba3069485faeee4930d52a795965443f073707ea8cc40c99c3",
+        "mips-unknown-linux-gnu": "26c31d3cbd2797c7175d54ccf3bffa76e169683ac25e884f2866a6c261476198",
+        "mipsel-unknown-linux-gnu": "84afdb4c88112d06b88743e24ab86475296ffa8e9f56180c9572c5eb679e6478",
+        "powerpc-unknown-linux-gnu": "033305c6a9f543ee702060114577ecd5a7ba7316f2a7f48797f1296baace36b2",
+        "x86_64-unknown-linux-gnu": "0449a5219eaf05c53a141ee664afcb46c75c78b6500d0b082b544baa72a78cbb",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "5a46dbc72fd0ada9836fb82bf0a35077",
+        "arm-unknown-linux-gnueabi": "19d1254dcd6bb0da48eaee1546b4c74d",
+        "arm-unknown-linux-gnueabihf": "4c7d61cc1676f9cb62eaaf706dffe376",
+        "armv7-unknown-linux-gnueabihf": "e071ddcb3a2643675643019fdb3f0b7f",
+        "i686-unknown-linux-gnu": "b7103a21a2b1e49aa2e9be42ce7c0d1f",
+        "x86_64-unknown-linux-gnu": "f3f13b4f7a886648da9cd21c57513bf8",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "e70475d2770a20bc290e233d0dbe871d802fa36ec2fbbc4a80d247febbc92048",
+        "arm-unknown-linux-gnueabi": "aa9686bd1c5b6326ee22645b881782e04ef87f7aa60708764020f25ddae4799e",
+        "arm-unknown-linux-gnueabihf": "7f2835075e5d820b61e6d13be01290b8f60492650b8a04d961765d0a61c8c978",
+        "armv7-unknown-linux-gnueabihf": "9a8d86099be6e27dafe1ca7c8d2e1163745ee136a3f300021d40bc6ddbf31ce0",
+        "i686-unknown-linux-gnu": "505865fe26c7fb750cc5627854ffaeb02fdcea9aa8c6719ecd1f233d7fcf3f43",
+        "x86_64-unknown-linux-gnu": "1c749e7f5b5315977611a158da876589ec062bd07b6c96b73b756163e8a3d2ef",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=92289ed52a60b63ab715612ad2915603"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.66.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.66.1.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "7eb65b9c155bd0da3e765a5e37f117f8",
+        "aarch64-unknown-linux-musl": "35ace019bba2e1ab81fa20a9443b3b03",
+        "arm-unknown-linux-gnueabi": "e451c9d782e78ab5f62329176b25ffb6",
+        "arm-unknown-linux-gnueabihf": "726d36bc8d330fadac282935e134f24c",
+        "armv5te-unknown-linux-gnueabi": "3cafe5fea1c2322b3bb9e19b683017be",
+        "armv5te-unknown-linux-musleabi": "b7985cac7d0a00aaaafc75a628c422b1",
+        "armv7-unknown-linux-gnueabihf": "05e483655f6cc825bab204269d5075a7",
+        "armv7-unknown-linux-musleabihf": "a5b41b026fd23cc1cdfcbc554b69e7dc",
+        "i686-unknown-linux-gnu": "f2c6072cdec5d2dae68ba82569b0b8c8",
+        "mips-unknown-linux-gnu": "4e8fdcc2c37b343657217e35bcfe61bc",
+        "mipsel-unknown-linux-gnu": "889e10d7127359c96d6f1d9e67c0f26f",
+        "powerpc-unknown-linux-gnu": "f7f761f8bd91684ab447aeedc2417332",
+        "x86_64-unknown-linux-gnu": "4e1545cd02387cc624e06e405631b850",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "0ab8e60caf3c63f687d02f16cb577da86ed292481fda29da9e9acd53140f9b31",
+        "aarch64-unknown-linux-musl": "5fe9813f157add9291cb7bff633bdaea567f232a882b39c8383029b51de11d97",
+        "arm-unknown-linux-gnueabi": "35cc58bc6c9390f99bb1ae49b6273576f08c99609f0aa33c3b7ad0d4bc9ede3f",
+        "arm-unknown-linux-gnueabihf": "db178fab229f61a21368718330dcd749171439abf60bf14a2ac415e96e624226",
+        "armv5te-unknown-linux-gnueabi": "2267f1149fe323ceaced52c638a8c6d82c8485724757903804b839f3e4d8b08f",
+        "armv5te-unknown-linux-musleabi": "7c8a14b71589f26a3a8aa3a4ad1bd46d50df9538b0ec603e22f4687f78d8b6dc",
+        "armv7-unknown-linux-gnueabihf": "c4150af5f8366cb4a9e1fe4bd982ee84bb66789c3b5085c55f6f7ba8012a8feb",
+        "armv7-unknown-linux-musleabihf": "bd43b68a4384acd7a5b862e2260c3a1eff8897e4e7fca1a7032d20e8e7c1c701",
+        "i686-unknown-linux-gnu": "e8a937cb56aa2f644a537f403b4e92978cdb17a2e4d8b737f4a9743bb17724b4",
+        "mips-unknown-linux-gnu": "d61188ea93c117fb7534bd49c46f2f0116bc880f8e49a591688cbc2d4eb594d6",
+        "mipsel-unknown-linux-gnu": "cdc9a4caa8356e49c7f5d0806bf8f8cef693eb03e42d875388abc0bbed9b8099",
+        "powerpc-unknown-linux-gnu": "c70872a80ca38b2daa83132da5ea979e443c8d973d4692fbaee8b9134926c8c1",
+        "x86_64-unknown-linux-gnu": "b225606cd0cf02b1f5fc77420647a28b35f22d67e565dcdbe29f0c919245565f",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "f2cba011c559934a6d9c047a7ac144eb",
+        "arm-unknown-linux-gnueabi": "b3853d9ee36f32ce72b53e6f434b7544",
+        "arm-unknown-linux-gnueabihf": "a472e56450a354a52dcda765574dd09f",
+        "armv7-unknown-linux-gnueabihf": "c6180907a93578c6d566705ec1b9f5c4",
+        "i686-unknown-linux-gnu": "cd465741cd04f1a076cd700f329f2603",
+        "x86_64-unknown-linux-gnu": "377660256a84456d0f8e12f4ef705283",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "d268a5c65154613349d0f4d35456f0f6a62da1b94490bf63930405d077a3a1df",
+        "arm-unknown-linux-gnueabi": "09235884c8b7779fff62e15efef97b2f894970df7fc3159ed526822bb9720f46",
+        "arm-unknown-linux-gnueabihf": "3d5afab28d52fc4d5e2d27c937a45b3ff287833d104ee264d3dc010306fdaf18",
+        "armv7-unknown-linux-gnueabihf": "37b5574893a636f8ac6a506b8b7fcda0fae23996ed86d9bc8bc330ac95e96abf",
+        "i686-unknown-linux-gnu": "61647bf6cf5d0210c069e05f0b9ebad41f44f3c15b44a3a4543e14e64fff75b9",
+        "x86_64-unknown-linux-gnu": "a3aa1c42ca384fa3a0cb6817d00affb47c747c28a92072d2353bd103c9973a03",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=92289ed52a60b63ab715612ad2915603"
+
+require rust-bin-cross.inc


### PR DESCRIPTION
Autogenerated by running `build-new-version.sh 1.66.0`.  Updated the README too.