### PR TITLE
Add Rust 1.67.0, 167.1, 1.68.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dependencies as well as default compile and install steps.
 
 Currently supported:
 
-  * Rust 1.66.1 (and many older, stable versions)
+  * Rust 1.68.0 (and many older, stable versions)
   * x86 (32 and 64-bit), ARM (32 and 64-bit) build systems.
   * All Linux architectures that Rust itself supports (Multiple flavors of:
     x86, ARM, PPC, and MIPS)

--- a/recipes-devtools/rust/cargo-bin-cross_1.67.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.67.0.bb
@@ -1,0 +1,51 @@
+
+# Recipe for cargo 20230126
+# This corresponds to rust release 1.67.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "052d51d30067f9a9e50dbea7f605ea49",
+        "arm-unknown-linux-gnueabi": "81dc2a0d2c0304c1a94ef5cd41891132",
+        "arm-unknown-linux-gnueabihf": "5838391451d2c6f54de85c2a2b38b63c",
+        "armv7-unknown-linux-gnueabihf": "c35915033b1ab05e6fb6408a3cf5394c",
+        "i686-unknown-linux-gnu": "928427ba5ad99b9e7f9d234769713812",
+        "x86_64-unknown-linux-gnu": "1dedb4ce0c60fcf2700156181d81639c",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "b7ee9078f9543fbd93702e17e01b42b2a494d5501125fb3104200a8bb5fcfa43",
+        "arm-unknown-linux-gnueabi": "14efa5bfa5989e6062081b55f1ef2aed4894cad87a13928b4e2da98011a292ba",
+        "arm-unknown-linux-gnueabihf": "f3a7242d639c95129de21993c01261fb291be33a8245d2a62905868e124a22ee",
+        "armv7-unknown-linux-gnueabihf": "0640fb8f2a2e0fdca0b6517ad7310b4d2361fc529e330d78aae3480c5a8d4d6d",
+        "i686-unknown-linux-gnu": "d8055c407229127cbda09298f150b964424761ad1c3eca04e49f3e84f0ede832",
+        "x86_64-unknown-linux-gnu": "7c70e350b139fa51ece48cc19cc7c61bc4d9ba5d15733a4179d27a51f58bcdc4",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-01-26/cargo-1.67.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2023-01-26/cargo-1.67.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-01-26/cargo-1.67.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-01-26/cargo-1.67.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-01-26/cargo-1.67.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-01-26/cargo-1.67.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.67.0)"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.67.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.67.1.bb
@@ -1,0 +1,51 @@
+
+# Recipe for cargo 20230209
+# This corresponds to rust release 1.67.1
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "c679c21ab30494545c4c9914e71dc6ff",
+        "arm-unknown-linux-gnueabi": "5500bd07b57f7f254543724c92a05971",
+        "arm-unknown-linux-gnueabihf": "024ee9b53b3400189e8b7d16c337ce21",
+        "armv7-unknown-linux-gnueabihf": "bbfbe273b8abf73f18cb6b9542e98508",
+        "i686-unknown-linux-gnu": "590f077256744bce27e2297870c3e8ff",
+        "x86_64-unknown-linux-gnu": "58ac3b83d186b5b42c2168e81eb439a1",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "e1ab1452572cb78fc7ec88bcadb2fd3e230c72b84d990fd6fc4ec57a24abdb2f",
+        "arm-unknown-linux-gnueabi": "48e16568801f31e9299d38d15ec95aebe8f1b5b7d78bc98f06ccb912c9a10d41",
+        "arm-unknown-linux-gnueabihf": "e3cb5ec5192f040124713c08c2cdf056c0f4be26c563a0b6e22a95c0a67e0d4a",
+        "armv7-unknown-linux-gnueabihf": "8de3e98677f38a4498ade080dc3417a231fe63a88b6b0996fcd9161f9791d67a",
+        "i686-unknown-linux-gnu": "3d0d7d1c02701babb65e276d6359847e91e8ebe5dfdb51fbcf90fe3e96f5487f",
+        "x86_64-unknown-linux-gnu": "8d9310dc1e8d36ebd8d56ccaddb0c854daddb6b750c147c141be04f0ec6e89f0",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-02-09/cargo-1.67.1-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2023-02-09/cargo-1.67.1-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-02-09/cargo-1.67.1-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-02-09/cargo-1.67.1-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-02-09/cargo-1.67.1-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-02-09/cargo-1.67.1-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.67.1)"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.68.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.68.0.bb
@@ -1,0 +1,51 @@
+
+# Recipe for cargo 20230309
+# This corresponds to rust release 1.68.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "b0c3488cd5ca0dc3022e27a62ba59975",
+        "arm-unknown-linux-gnueabi": "e7c68fbc07524e613eab5c70aabc9c4b",
+        "arm-unknown-linux-gnueabihf": "ac4147bf5b4f503ba21fecab37d78347",
+        "armv7-unknown-linux-gnueabihf": "061496b556e092942220dfccb5784ea2",
+        "i686-unknown-linux-gnu": "6cef3c2e19b52f48facd19500c2a9d93",
+        "x86_64-unknown-linux-gnu": "abaab0dbf00e173a59a7b698c262cde7",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "8f665f6dd1ee4c7ffdbb4ac886dd1252c052689e0b982f92894b84e180af1871",
+        "arm-unknown-linux-gnueabi": "8af2c88d6d846012da42a42b09e296b7a954b2c7c1f86df5e970738d8b9b940b",
+        "arm-unknown-linux-gnueabihf": "69f016a0e8203be57325ab2c0f281c13ee6a34c69916346bc239bf956db568dd",
+        "armv7-unknown-linux-gnueabihf": "13d4b4345e0b4f50da1d4d5649f137cd7243d0326cccf997943b11674ca244f4",
+        "i686-unknown-linux-gnu": "ea5c7e7e68e3543c2149880b002e7d5619a40cb0096ed3113c7acd1f3a97a2a9",
+        "x86_64-unknown-linux-gnu": "c9a841bfaf5adfb0c77b66bd83f0aaf0b5a1056054d5e133bb5cef821e2336e3",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-03-09/cargo-1.68.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2023-03-09/cargo-1.68.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-03-09/cargo-1.68.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-03-09/cargo-1.68.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-03-09/cargo-1.68.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-03-09/cargo-1.68.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.68.0)"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.67.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.67.0.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "c3d78762dda87793df7044e407432aa8",
+        "aarch64-unknown-linux-musl": "0b37dc5a6e59a7749d87e2f73853a2d3",
+        "arm-unknown-linux-gnueabi": "35f2940888f618e77a4298b88a3ef7f8",
+        "arm-unknown-linux-gnueabihf": "4971f0010b41102fb193e9f5101a2c3f",
+        "armv5te-unknown-linux-gnueabi": "9cb692a0acb9495dd1e13d6cecf26282",
+        "armv5te-unknown-linux-musleabi": "25b82de629636160769e1e978885b3ac",
+        "armv7-unknown-linux-gnueabihf": "9d37aab7c50b122d6ef16c791c95940e",
+        "armv7-unknown-linux-musleabihf": "b97c2f5636971b886913ea3972e57f68",
+        "i686-unknown-linux-gnu": "db3765fc976f13c11dd311c455737189",
+        "mips-unknown-linux-gnu": "0ef39bf1882411ee226fb4e13fd22cb7",
+        "mipsel-unknown-linux-gnu": "4feea2392240121a5b8eaedb02edae86",
+        "powerpc-unknown-linux-gnu": "9931a9713c94f8ab837e6b2b867f5e4b",
+        "x86_64-unknown-linux-gnu": "8bf77dfb3e418bbd83cf03aa2a29a581",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "cdd6cd98e80a8ff130f2f0f8f78d51fa012ca55988bfc3a108f684b3cf331295",
+        "aarch64-unknown-linux-musl": "1f1239d417894dd0d56cae7b264ee88ff13ecca0d01416d14ba069bbde6a4e40",
+        "arm-unknown-linux-gnueabi": "9e2b3b3e2e291002d1dcccf983aa48aeadfbdcdf7299861d3e25cf4cfad964f0",
+        "arm-unknown-linux-gnueabihf": "e37b5185e8a583aff8144af2f5e72cab52747ba39e98f43ab4cdd96202e78be6",
+        "armv5te-unknown-linux-gnueabi": "f0dfa7f9bf08c334567450189ca7bbeb48854c666efe8c97d994f770e819712a",
+        "armv5te-unknown-linux-musleabi": "4936fd71bbd9667be3872ff8f53e88b3a9edf9e7268458738046824a28c6c82d",
+        "armv7-unknown-linux-gnueabihf": "0ac50c8ea22308044125c0956ab916d16160b5b0cd01b7479c868e65320467e1",
+        "armv7-unknown-linux-musleabihf": "6d8a092005fb8ea480a84346bde55047e8b0e23b78f37e38b482aad9e4649fea",
+        "i686-unknown-linux-gnu": "71e0ce5ae10f4b48fe8b45fcc0b7f2e70bad29f1095f4251c838cf070465beb1",
+        "mips-unknown-linux-gnu": "25408c8cbdd8bd6fda789e71c4774692480c16cf0d40f416954116fad569bd3f",
+        "mipsel-unknown-linux-gnu": "6c4522b65c20e5cc968f7e3b9b79506051c2026ad1264435705344a6c6d7f472",
+        "powerpc-unknown-linux-gnu": "379c4f43c5ad7a5237a44bc1618ef264005957974417580cc32150ed30ef718b",
+        "x86_64-unknown-linux-gnu": "eb334a2e07da87c749010844a70d815efddfe6f2572faafadbf126458a2724ca",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "1c0bcba54792972b3962dd9d5f9c1d5d",
+        "arm-unknown-linux-gnueabi": "924ad9171475158bf264d02cefe3064c",
+        "arm-unknown-linux-gnueabihf": "51287235c487baf34cd42970b214b33a",
+        "armv7-unknown-linux-gnueabihf": "b9fd83ff85e652c1895f90811c966c9a",
+        "i686-unknown-linux-gnu": "51804dfe95089fc721db0c2c164312ef",
+        "x86_64-unknown-linux-gnu": "ce44c5575d8d49e1dcd188f7b6f3c4ee",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "e6e1d0299de9a74ff43c894329da4062281843bd0b1bf422009b2cbc6b6b7c6f",
+        "arm-unknown-linux-gnueabi": "4e8b8ec1b302c599d471224e4a03e204aab19028bc8a52feddeb51a86f0591c0",
+        "arm-unknown-linux-gnueabihf": "cfea1b7953b0dfe93966970dffbcc32e506eb61c2a346c4e1b19e860ed84fc74",
+        "armv7-unknown-linux-gnueabihf": "8a909f2ed63fb898439c80efc963751709a0c62e48e8e5554435ce7ba3325d6f",
+        "i686-unknown-linux-gnu": "aafdca2c01912198c5d906da823400ed6e0cfc5e9a121d978484fb1b7c09c661",
+        "x86_64-unknown-linux-gnu": "a1dbe7e5db23c4dd5a91b604315fa8b36cf5eef6274ce65ab6b0efc1b25b37b0",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.67.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.67.1.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "b27fd774ccd759f131993cae7a50a61e",
+        "aarch64-unknown-linux-musl": "9338f6946122cc0b930994170da76981",
+        "arm-unknown-linux-gnueabi": "fc95daea4a8e0a0977c313c32eb93daf",
+        "arm-unknown-linux-gnueabihf": "1919b010b7fe6555e5bd7c8acdec721e",
+        "armv5te-unknown-linux-gnueabi": "3c2075114d4b20d7ed7af1c68ac88edb",
+        "armv5te-unknown-linux-musleabi": "d3afec1be337ef7f2b21b9c6fc49d571",
+        "armv7-unknown-linux-gnueabihf": "594d5b87a42caab5db2d6c1f083c922f",
+        "armv7-unknown-linux-musleabihf": "bb6013f4fabd0696f56d36345c5bf50e",
+        "i686-unknown-linux-gnu": "3727ee658a79622ca7b8a30c60f7cd79",
+        "mips-unknown-linux-gnu": "aab8a4259925f3cbe3e8adf8cac08678",
+        "mipsel-unknown-linux-gnu": "9971cd62223276aacb2ae186b38471ea",
+        "powerpc-unknown-linux-gnu": "c1b7f02188225c8b2ad2a15326c1300f",
+        "x86_64-unknown-linux-gnu": "453d6a64eaf9b7e2a67a84911949fc03",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "19f3afbe43c7e041b8b5c0143101d3ede92f73f720709ef1578ad5d259ad6181",
+        "aarch64-unknown-linux-musl": "b34e7728ea06ffccee03ec2334a57cf2445d479bd46bb846992d5bb9c1d72873",
+        "arm-unknown-linux-gnueabi": "26e290910b2936bfc800f9f7e9ffd81c4733fdf52b117ee42ce7def70105b87e",
+        "arm-unknown-linux-gnueabihf": "6eb6f4b915caa058f0b1fd6485283215ab628b6bd415abc343ccce054bf66131",
+        "armv5te-unknown-linux-gnueabi": "c04a9cf0a41df4b170a1e29700597fb424ebbb33ff357e935bc361cc0fb88d98",
+        "armv5te-unknown-linux-musleabi": "010020d3677e40aaacf3c624172e4a1615fada25556a43d3f648af4ad26f4c8c",
+        "armv7-unknown-linux-gnueabihf": "711aba76f98f630b6b51ff4e72ad350382e325bf8c06a7f6a949f12c44dbe5ff",
+        "armv7-unknown-linux-musleabihf": "420e1fbb2309b3083c892279b74d41f95462067a92b3e059e0cef0829b6edc6b",
+        "i686-unknown-linux-gnu": "af9dabb8126b7dfaa00eefc2a04b304685109b33929c54b6f4ec0e523776a8ce",
+        "mips-unknown-linux-gnu": "40fb4fca0af8fc3452fcd589e0c1b265f53816bc5e742a8033ca6545a5a69dab",
+        "mipsel-unknown-linux-gnu": "940132da5f30f86a4cd87b1c9c37b4f9a6e0cebaaf5d74d187be72383f571a13",
+        "powerpc-unknown-linux-gnu": "61d376eca89cf0a1b103824862651f7ad5abd7d4bc0f604f8f2fbb261cea8a85",
+        "x86_64-unknown-linux-gnu": "31dfc19ae5821c0542975111574aa8cc7e0b2e1a95204f6cff7572f183524626",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "89e560811396a4cbe49a7af9960455c0",
+        "arm-unknown-linux-gnueabi": "b8896ee0a34fa7fc0177062f169fe567",
+        "arm-unknown-linux-gnueabihf": "17261caddbdd92c9e00258d63635b7c1",
+        "armv7-unknown-linux-gnueabihf": "e0c79f254212a41b68001793b1cece06",
+        "i686-unknown-linux-gnu": "4bd893c93a3b9b03917755d331c4b3fb",
+        "x86_64-unknown-linux-gnu": "7a357021c1513af5343aeb428939329c",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "accb1afa2674730b69a762f79b4f71bbb5211c4f5b022b115d8e034775dba5ad",
+        "arm-unknown-linux-gnueabi": "340e21d21078a91e411c98043d4b618f155ceff77f542e7d7b0b0a9e77d5740e",
+        "arm-unknown-linux-gnueabihf": "c764753baf1707a8f82489c0ccaecffbba1d7d0c57f5b21c546c3d08aa66da45",
+        "armv7-unknown-linux-gnueabihf": "db39bbfdc665a585c811d6235823b525d5b642803f4c66d7162e9bc22b79f1f1",
+        "i686-unknown-linux-gnu": "4dd74d1fa7af449a4296f5308da95a5cce75142d0b79dd956bccba7ea2dc461b",
+        "x86_64-unknown-linux-gnu": "11115542833004fff465fdc86994245b6446d988aebd42153203a6f9c3aeccef",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.68.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.68.0.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "36f21a0c6d38db78b5de96b26f83f0b4",
+        "aarch64-unknown-linux-musl": "5fc9bf7a99082795af64477128eab6f4",
+        "arm-unknown-linux-gnueabi": "20d2f77aa83b165c1b2947293410e597",
+        "arm-unknown-linux-gnueabihf": "7f1733f938f3f0d5e0f89a83b4964a43",
+        "armv5te-unknown-linux-gnueabi": "42f9d699d9747528492ab8197d7f2482",
+        "armv5te-unknown-linux-musleabi": "324dfa0ade2034d16dc2e961ac10510b",
+        "armv7-unknown-linux-gnueabihf": "1d73e9dbb93a17eff8daed594f3c1b4b",
+        "armv7-unknown-linux-musleabihf": "79f20ed1ad2eb10f76d6d445af02b2ad",
+        "i686-unknown-linux-gnu": "3240c05b0f63ac85b0e8891c38fde126",
+        "mips-unknown-linux-gnu": "2c44533173cd2c6602a6f46dabb8ce13",
+        "mipsel-unknown-linux-gnu": "cf2d3686a4e206abcf485d665465bf5a",
+        "powerpc-unknown-linux-gnu": "faa9be4d555d4ae20054f67b81868209",
+        "x86_64-unknown-linux-gnu": "46c9c8247bd7096baefb195d01258176",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "fd1d3123b12ef497c6f5a87d4a831ef3ec5942d03e5d4e2fcc6ec5ddc3935759",
+        "aarch64-unknown-linux-musl": "fe17df6947ed566e3a1dfb61455c6b566dd04a4668f6292781b897b76da79a2f",
+        "arm-unknown-linux-gnueabi": "b8a6bc5f1792a7d1d3b424681f4ea9e9d2b5a9b5dd7d53940a3a0d6a1aa7aab7",
+        "arm-unknown-linux-gnueabihf": "0f9d5bfba15980023bd55e2658e12688497ff845ea928369420410f9d304c497",
+        "armv5te-unknown-linux-gnueabi": "383db858d4ec8569fe2ab2c8380e5c73024519bb0bd8eefbe9d1dbf58fa109cb",
+        "armv5te-unknown-linux-musleabi": "346414c7666d6cbfaf9c0f1100565441aa9ecddd353a518ff114ad38c3eb749f",
+        "armv7-unknown-linux-gnueabihf": "e919a141af4aef500059a80cd7746aadb80dff88676e6919a0ee4f74c2272569",
+        "armv7-unknown-linux-musleabihf": "52975246828ecd59164aa5b623c4dbc1e466712bb4ae3015e0a463e1214755a2",
+        "i686-unknown-linux-gnu": "d9d4572a5cfd668ecbc219a42786ac2d6aa18708447c987965ef2d1c2ada661c",
+        "mips-unknown-linux-gnu": "dd76eec4760f056532d5719621dc83c0d83a76970ce850cdecd9a7aa1a65902e",
+        "mipsel-unknown-linux-gnu": "7afdbde48352f41229f5819e3f3fc5e09711688f91a482002295e7da011517a9",
+        "powerpc-unknown-linux-gnu": "23d2fcedad4102d884cb35774a6ca8d765e0e07825dae64dbda19112ad99d6e9",
+        "x86_64-unknown-linux-gnu": "67b8cb1610b254c296107e2516083897aed2996bb7618561520e0a1f0923c696",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "94974c13814cbcb5ff2f90dc941888a2",
+        "arm-unknown-linux-gnueabi": "025ab9f13f2c7c60bb793606adc5877d",
+        "arm-unknown-linux-gnueabihf": "b2bc73df403f8c3267c50fb9466c0a71",
+        "armv7-unknown-linux-gnueabihf": "984796dc77369902e8f6cfa5e4fa0a5a",
+        "i686-unknown-linux-gnu": "e93cdd6520fabbea24e5f5036b3b2502",
+        "x86_64-unknown-linux-gnu": "c44024f8b7a4c58e657d1277445b664f",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "43f103a98614196b58e0f9c04794eb10e55433e44d456bb28d02ac8d5e52fe4f",
+        "arm-unknown-linux-gnueabi": "dbc90602c4755f914370b8e1868bfb428d19aecdda451fca88e486a94b12418f",
+        "arm-unknown-linux-gnueabihf": "86189c70c48768429adb4bbeb652526f3d180827aa2f6827e8b9c5756e1ea2ed",
+        "armv7-unknown-linux-gnueabihf": "49669fc940ef07924bfad801ff63d9e94bf311a2affe8f11c15fcb39a356d099",
+        "i686-unknown-linux-gnu": "f2b914352e35938635956033450f3229c8f1fa7de2017d5f7f6205ff73552b2f",
+        "x86_64-unknown-linux-gnu": "dbb91e39698e2fca9ebaf6439a706b3ea723ac507903c046ecafcb5151c5a74e",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+require rust-bin-cross.inc


### PR DESCRIPTION
Autogenerated by running `build-new-version.sh`. Updated the README too.