### PR TITLE
Add Rust 1.69.0 and 1.70.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dependencies as well as default compile and install steps.
 
 Currently supported:
 
-  * Rust 1.68.0 (and many older, stable versions)
+  * Rust 1.70.0 (and many older, stable versions)
   * x86 (32 and 64-bit), ARM (32 and 64-bit) build systems.
   * All Linux architectures that Rust itself supports (Multiple flavors of:
     x86, ARM, PPC, and MIPS)

--- a/recipes-devtools/rust/cargo-bin-cross_1.69.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.69.0.bb
@@ -1,0 +1,51 @@
+
+# Recipe for cargo 20230420
+# This corresponds to rust release 1.69.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "52e7207c3409a9db6c9e38f0257f77e2",
+        "arm-unknown-linux-gnueabi": "451a3e9ec6228cfc4066732cc2d7a672",
+        "arm-unknown-linux-gnueabihf": "8f4383b886ae7fb3782ba4daba0b0a7f",
+        "armv7-unknown-linux-gnueabihf": "25c7ce4495a5a6fd2ad1e5dabc5ffd73",
+        "i686-unknown-linux-gnu": "27db5dab5f94f8c81faeeadcaa8f5197",
+        "x86_64-unknown-linux-gnu": "1fdaaf9b81ccee41ba54451f7951480f",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "6ba6e4a9295b03d01b7dac94b7941d71c029343dc3abfd6cc4733a99fc3c7976",
+        "arm-unknown-linux-gnueabi": "0d93ea24db4e3fc7739c68661a466fa4fbe8e158c1f10ef06e8d9cee1f7de73f",
+        "arm-unknown-linux-gnueabihf": "dcc8d9dffc209bd665ad45586b271569a261795162426ffbab24336e04f7a3c6",
+        "armv7-unknown-linux-gnueabihf": "8cd5ca78c7efebcd735b7264f8a926480f4bed334b9e031d68f75494e669ff60",
+        "i686-unknown-linux-gnu": "45f966d2965e41e0598fa9dce780766163685935647c8de09610c73f5f85823f",
+        "x86_64-unknown-linux-gnu": "7ee899206f592a86687478465970aa6b57772ccbe9a1f1b7695aa1237c2325a6",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-04-20/cargo-1.69.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2023-04-20/cargo-1.69.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-04-20/cargo-1.69.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-04-20/cargo-1.69.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-04-20/cargo-1.69.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-04-20/cargo-1.69.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.69.0)"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.70.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.70.0.bb
@@ -1,0 +1,51 @@
+
+# Recipe for cargo 20230601
+# This corresponds to rust release 1.70.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "37c1fddcd3767327705a770320bf1d45",
+        "arm-unknown-linux-gnueabi": "8677c112a3f1928e05c02a543d915244",
+        "arm-unknown-linux-gnueabihf": "89c9355b85e10bd310d5ee12d004f7fb",
+        "armv7-unknown-linux-gnueabihf": "dda0f0c088bd92e5b2a170ac79d1a872",
+        "i686-unknown-linux-gnu": "eca8850bb7034c2cf1ff70102886880b",
+        "x86_64-unknown-linux-gnu": "cdec5782eb3a19fd14b8e5583fb93855",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "b711859b9cc39c8c0aa5aa50559a2905d20fc229cfd5bbf9a7fdf02477d18e2b",
+        "arm-unknown-linux-gnueabi": "186fed2acd8bf9424c9d76cb22350d058ceff7c3d606c901005779c2bd92aeeb",
+        "arm-unknown-linux-gnueabihf": "9fc820a9391388207500e507eb317d48be396f2b244cc6ee6ca4677a6be8d609",
+        "armv7-unknown-linux-gnueabihf": "ce4de253a3fb1376701da5d2be4d1c338721695a9da027ac1d710f5d0a084ff0",
+        "i686-unknown-linux-gnu": "c8a53cfd0537e33585c8b9cd65fd73db9991453cfda421c28832338cd4af87fb",
+        "x86_64-unknown-linux-gnu": "74e049e657f544d146013746e53ecf427f47f0d5f1185bef1b28c2c8ace43253",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.70.0)"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.69.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.69.0.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "06f5c6c5f6414f466085f29115245cb3",
+        "aarch64-unknown-linux-musl": "c335170190f1f931b458f03dc47bcbaf",
+        "arm-unknown-linux-gnueabi": "4068c46d2e41dbcef176cbc3ac746c27",
+        "arm-unknown-linux-gnueabihf": "19cae266e76462f7206507ee65f824b5",
+        "armv5te-unknown-linux-gnueabi": "9496f7b2deae71facca6ce0e41850b83",
+        "armv5te-unknown-linux-musleabi": "d617e385a804a76ba09ee22e78bfc4ba",
+        "armv7-unknown-linux-gnueabihf": "1ae62f90f18889e99f88e9be75787bce",
+        "armv7-unknown-linux-musleabihf": "0a9f391525a0ce6632236400f6539fca",
+        "i686-unknown-linux-gnu": "109e0e1abcbeff7d44fed74c72802a59",
+        "mips-unknown-linux-gnu": "3ff8ccc3cef790995433c8542414e107",
+        "mipsel-unknown-linux-gnu": "285ca44b6cae1af4ea660178c9719035",
+        "powerpc-unknown-linux-gnu": "4a8ded79e923eb9afc4c5d750609c322",
+        "x86_64-unknown-linux-gnu": "d9a9bba8e16426b641f2f8113d9c4104",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "8f42b40c0a0658ee75ce758652c9821fac7db3fbd8d20f7fb2483ec2c57ee0ac",
+        "aarch64-unknown-linux-musl": "07788bc6a1d17e8f0791c3367734c3c65165ca806ee83d01dad303059690b19d",
+        "arm-unknown-linux-gnueabi": "096aa203d690339f3831052b9dac52d91cc5dd63627c6c89688c16d7f70dca4a",
+        "arm-unknown-linux-gnueabihf": "f0630a13adf0f86f5db528291a838645e31ce63e1e052ef5284aecd8ae6cecca",
+        "armv5te-unknown-linux-gnueabi": "2e6b90f114fb81cd8d746895560552d82c09c08bdac97116a29f336019ca3982",
+        "armv5te-unknown-linux-musleabi": "e51d66540ac036582d8a84af72a5a6da27bc338ea42fcbc5ca7679a8abb4acbc",
+        "armv7-unknown-linux-gnueabihf": "08edc4547495299393a0e18f8eff740d7cf31e00ad2b31671688e5e4438abe16",
+        "armv7-unknown-linux-musleabihf": "fadb41835ada212a248f663caa0c727e32a3c8d9471bea25f63a948b760e3124",
+        "i686-unknown-linux-gnu": "d54849ab7168e16210107b812871bea7f282a3f50b4b34aa252f04f25f8a8bf9",
+        "mips-unknown-linux-gnu": "032e5b35b2883a9a5fc29e191c1103be8ea33af90b35d26305da5bdb847dd65d",
+        "mipsel-unknown-linux-gnu": "3101831757ce93c10b4c394e1f979176e8d1ca72492247d2a043f4a9fcceb24c",
+        "powerpc-unknown-linux-gnu": "dd5c877591ad9df7a5cb541e23be18d1ca7ccc04850c20118b1eab35625845b0",
+        "x86_64-unknown-linux-gnu": "b6986b4042af7b17fc8f51127018617b32d45cd555c582efa816ac194d4b53df",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "8ec2b575041b8bfe7a2f9e3942474730",
+        "arm-unknown-linux-gnueabi": "eddf738af5a4348722d821cbd5f32bcf",
+        "arm-unknown-linux-gnueabihf": "89bd230acff44bddf8296698cfb73a6d",
+        "armv7-unknown-linux-gnueabihf": "8f1f40dbab07d1f4a9d21c9e772ede5f",
+        "i686-unknown-linux-gnu": "371ad2179819f2e24e66e79c33dbc51c",
+        "x86_64-unknown-linux-gnu": "0d8e7aeec55238c13d32c884cda88a62",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "b240a2d8182adb0aa2978ba8ec4812014b3a93a1aa36f10ca2ef3b1f4d80a47f",
+        "arm-unknown-linux-gnueabi": "6a32cf470f510d0882f9570524a5616db644df6a409c99922d5c74ed8bb8a42d",
+        "arm-unknown-linux-gnueabihf": "e5e5fa9ad8e7e5d455f515c8308e870b9916ad836f0ceb36897a16c3bab24924",
+        "armv7-unknown-linux-gnueabihf": "53dc923efcfc8c6dffe8a635d24668d0146732228deeb6a560e1e3baedfa4fd8",
+        "i686-unknown-linux-gnu": "aca43ad204a3ced049e389f4187afbe14015acdd803bdf6269b0a6a45ab9ffa8",
+        "x86_64-unknown-linux-gnu": "edd616432207bee868bd585fdd7c7229699f8bc3ffdcfc90e5a7404aba0d30f4",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.70.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.70.0.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "d0406889849c5bd8514c3dd44bd5b9b0",
+        "aarch64-unknown-linux-musl": "3d57f7a6c1683e70c745b8debf7b0438",
+        "arm-unknown-linux-gnueabi": "eefe9d61069ccf58080639fc9a906a20",
+        "arm-unknown-linux-gnueabihf": "11387d73303e267d76222d088929ba13",
+        "armv5te-unknown-linux-gnueabi": "2153afd3ada3f7fa70e585b7045c9457",
+        "armv5te-unknown-linux-musleabi": "69dde4aa40b8418150cd486cc4a247db",
+        "armv7-unknown-linux-gnueabihf": "69d5570003311cd9b3f9493d2da9d311",
+        "armv7-unknown-linux-musleabihf": "dce04c579aa064f9ebf943863ea0a7b3",
+        "i686-unknown-linux-gnu": "32095a189ab66b0d8fbfd3d20a7907f3",
+        "mips-unknown-linux-gnu": "f375cd20c5d1334521a279983c1cb235",
+        "mipsel-unknown-linux-gnu": "7e18d1d9cef2f7d72b61f9ddf429e918",
+        "powerpc-unknown-linux-gnu": "1661a71982ffbf30f0127e85f02665cb",
+        "x86_64-unknown-linux-gnu": "f94d293a8a3f8fbdedf5220c3f2676a9",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "78e8ce250a7ba30b7b9e55406915d42d160074c3a0e10540f13a69144c85a981",
+        "aarch64-unknown-linux-musl": "5a33fe20263781a6821d52d2b2712e5322d8c2e29311b70a9fb0d5d7449c2033",
+        "arm-unknown-linux-gnueabi": "0bd625326fa48ddba9a6d0de8a5a24eb9a415e599004875fec8edaea869aa468",
+        "arm-unknown-linux-gnueabihf": "ebe12136f46269365a291f742e69986eea6736718e3493e80444f4df5986e9a4",
+        "armv5te-unknown-linux-gnueabi": "2ec260dfaeec9d14e15e48735ddc257431b35c89a0e5bfc5050483b1f2d2ad0a",
+        "armv5te-unknown-linux-musleabi": "8c34946c2e11e8755999374bb8dbb35f7279c3f6b55277328c029cdbc2485343",
+        "armv7-unknown-linux-gnueabihf": "3e3687fa87ce6549cc1f508d4888508531d70482fce210c19dad24b29b8e4e1e",
+        "armv7-unknown-linux-musleabihf": "57d075caeac0ffdaa0c47accf7fdf6458f5b73fbd8cbe3c42937d348d422f056",
+        "i686-unknown-linux-gnu": "6cf40f9cd6efcf225fbd3a1da62fc589c4b946c6c3e25ab4fadaa4c948e10016",
+        "mips-unknown-linux-gnu": "c1bc7f7b963da3288bf5fa624c0e0511d1da8983bbf5cac6c3e305688a83d3cf",
+        "mipsel-unknown-linux-gnu": "248bf2b1e24d712cc20675d62ae5bc5564f1ac5825790cd95e2fa203da46b85d",
+        "powerpc-unknown-linux-gnu": "27c10ad6ec6fea23980a5b28d51bcdf9e4b7206636e1570bc994c0581f950907",
+        "x86_64-unknown-linux-gnu": "d921afdcf5218bfe144b74bd16b4c18d824bb6194e6ff92451f0ed749ca025f3",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "4a1c89e77e075c981ea4f018cc0a8734",
+        "arm-unknown-linux-gnueabi": "0a694703e358eda7ec753e8f48c4ae9b",
+        "arm-unknown-linux-gnueabihf": "797ce2c3d53074b17e61dd3350f58f84",
+        "armv7-unknown-linux-gnueabihf": "517ea50d5872f2236ec38671563360bf",
+        "i686-unknown-linux-gnu": "e92d5c197958f050f9a437ca2f735160",
+        "x86_64-unknown-linux-gnu": "c448b26d0a2db781c1ff17fb656c1823",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "4ede6cb7dd09415b7a75145397fe49023aec759e9f2435f8254b4d7aabc704bd",
+        "arm-unknown-linux-gnueabi": "5ca537ea37ae6789e740cf1ef5587d743b09a5d1ea1bea5f5256f9cf625f59b9",
+        "arm-unknown-linux-gnueabihf": "d2ef2939d6fe1bc6c8941653285fb21ef3780b3b3126f8ac7cdd1cdce5661177",
+        "armv7-unknown-linux-gnueabihf": "003c8cefb3d1c3abe087a7068b0cd4889d81784132697ccab24e81aa733a9935",
+        "i686-unknown-linux-gnu": "d35087bbebed15f8573b7882e44982979ba4ced828ab0ff00e3b415b232c5fe3",
+        "x86_64-unknown-linux-gnu": "532e773484a6df30996b3809bc2a000f1fbe3e5b966a09d3ec0133c57c25c0fa",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+require rust-bin-cross.inc


### PR DESCRIPTION
Adds `1.69.0` and `1.70.0`, generated by `build-new-version.sh`.