### PR TITLE
Export SSH_AUTH_SOCK to cargo build

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -121,6 +121,7 @@ cargo_do_compile() {
     export PKG_CONFIG_ALLOW_CROSS="1"
     export LDFLAGS=""
     export RUSTFLAGS="${RUSTFLAGS}"
+    export SSH_AUTH_SOCK="${SSH_AUTH_SOCK}"
     bbnote "which rustc:" `which rustc`
     bbnote "rustc --version" `rustc --version`
     bbnote "which cargo:" `which cargo`


### PR DESCRIPTION
Cargo can use this environment variable to authenticate private ssh repo dependencies