### PR TITLE
Rust v1.73.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dependencies as well as default compile and install steps.
 
 Currently supported:
 
-  * Rust 1.71.0 (and many older, stable versions)
+  * Rust 1.73.0 (and many older, stable versions)
   * x86 (32 and 64-bit), ARM (32 and 64-bit) build systems.
   * All Linux architectures that Rust itself supports (Multiple flavors of:
     x86, ARM, PPC, and MIPS)

--- a/recipes-devtools/rust/cargo-bin-cross_1.71.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.71.1.bb
@@ -1,0 +1,51 @@
+
+# Recipe for cargo 20230803
+# This corresponds to rust release 1.71.1
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "afb5409c344657c2b062999c6b195704",
+        "arm-unknown-linux-gnueabi": "968ba43eff5a824dcdeecc9d703fe281",
+        "arm-unknown-linux-gnueabihf": "34c624ee97a95205642c8520f38d97be",
+        "armv7-unknown-linux-gnueabihf": "156f9b47ac705a7f447c5216086f7ec9",
+        "i686-unknown-linux-gnu": "63adaf5790373cf120e9cd1787326daa",
+        "x86_64-unknown-linux-gnu": "7cfe9643d2a458912f18a389cdc13fa6",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "a98d1bc375f87385c8b8113c7c1f5c56f66ce4464f8899ff92b2634acaa83aea",
+        "arm-unknown-linux-gnueabi": "849d89e3d5495e9b8e2ad824796c11d1db26888c75b1ea75c9b998a045f03416",
+        "arm-unknown-linux-gnueabihf": "30d2426de77d770c310f055263835180835c1701c6c8f023ab799fbeaeee74cd",
+        "armv7-unknown-linux-gnueabihf": "186e94d28463de82c1f037b153f7fe54fe8b62a8e38da93032e65dcd365c8690",
+        "i686-unknown-linux-gnu": "5c1e2d87cde0bb02e2d0daf05990c4c6df11a099765555bd1d1e44c9642c21c8",
+        "x86_64-unknown-linux-gnu": "7fc7963d663c888ea862fe1546a4a2e174dbf0d017ed3c8c5260fc5573d279b6",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-08-03/cargo-1.71.1-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2023-08-03/cargo-1.71.1-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-08-03/cargo-1.71.1-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-08-03/cargo-1.71.1-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-08-03/cargo-1.71.1-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-08-03/cargo-1.71.1-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.71.1)"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.72.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.72.0.bb
@@ -1,0 +1,51 @@
+
+# Recipe for cargo 20230824
+# This corresponds to rust release 1.72.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "672d941ceeffe8f838119cd06e438b0a",
+        "arm-unknown-linux-gnueabi": "4b9c8e1870dd6a35abfe38e3c1c5b94b",
+        "arm-unknown-linux-gnueabihf": "92af47d5d67015f37d7a878a33d5349e",
+        "armv7-unknown-linux-gnueabihf": "804c224eaede5d86d85009c5330ceec5",
+        "i686-unknown-linux-gnu": "d35031cd39a5c3d3d8c607c62ec218a3",
+        "x86_64-unknown-linux-gnu": "827dddf4ac4258c52b97afd86992281d",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "ae2414ed0e30340fa2994e1c4b4e809c2bb1a3c054de395540f5ec1aa1b35072",
+        "arm-unknown-linux-gnueabi": "9446f3dee453c5877e694879e4bcf506cdda5de61ea9400b75ec11e166a0ebd5",
+        "arm-unknown-linux-gnueabihf": "23a6bf57c1fefad844a3d9c1a43a3160a657dd8d7ff25c287fa7924c83c4d835",
+        "armv7-unknown-linux-gnueabihf": "b8b5ec8b1249982f80583f49b7035bcd666c11441600df5ee72b3b866712f8d7",
+        "i686-unknown-linux-gnu": "0b0f5e94e91762be981e5e4b4bbc8381aab1481cf93e24124be17e445c33547e",
+        "x86_64-unknown-linux-gnu": "bdd0589277041b7e6375e2782f9ce197f454f735642f118acb3a2d8e422770a4",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-08-24/cargo-1.72.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2023-08-24/cargo-1.72.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-08-24/cargo-1.72.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-08-24/cargo-1.72.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-08-24/cargo-1.72.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-08-24/cargo-1.72.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.72.0)"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.72.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.72.1.bb
@@ -1,0 +1,51 @@
+
+# Recipe for cargo 20230919
+# This corresponds to rust release 1.72.1
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "70df0ef7374f8f01048cb9cb1257d358",
+        "arm-unknown-linux-gnueabi": "d7103271e6272f914419eef4a3a8cbff",
+        "arm-unknown-linux-gnueabihf": "877e9de5bf0473a4c2042ae7a79a21ce",
+        "armv7-unknown-linux-gnueabihf": "42176c779e172c49edd9b1f348420faf",
+        "i686-unknown-linux-gnu": "613251f8fa9a4d33f340d87541ad52b2",
+        "x86_64-unknown-linux-gnu": "836d30d0fd4c7773edb21e89c3c6ca63",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "ad282984ef42304a1c700ecf47f75344c69bdcc0f682d61c46a8584d6e3e904b",
+        "arm-unknown-linux-gnueabi": "bf5a447214e5c838d7f57f9c115543ff509960c15a108a42e404373eb58f1c78",
+        "arm-unknown-linux-gnueabihf": "386cfe89d1dc1c33ace2aab8afdbe8db124474d5b5df2a767cea246cbc905e03",
+        "armv7-unknown-linux-gnueabihf": "065bd9acc3453806ab97b311d7171b567dfe8a988ff9e72b309a299008b954b5",
+        "i686-unknown-linux-gnu": "892034f264f86d45c5015c19f02b179711178ea2a64c24320d1584a789bb3e03",
+        "x86_64-unknown-linux-gnu": "8eeb3412ddec7be32bb8599a7d86c8a5e3a09b82ca8d870f3b30133bf478a155",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-09-19/cargo-1.72.1-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2023-09-19/cargo-1.72.1-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-09-19/cargo-1.72.1-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-09-19/cargo-1.72.1-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-09-19/cargo-1.72.1-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-09-19/cargo-1.72.1-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.72.1)"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/cargo-bin-cross_1.73.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.73.0.bb
@@ -1,0 +1,51 @@
+
+# Recipe for cargo 20231005
+# This corresponds to rust release 1.73.0
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+def cargo_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "7c4283462f4057a20204680d72fa75a0",
+        "arm-unknown-linux-gnueabi": "93f47810b6ce1deabbaebdc4ae02bcfa",
+        "arm-unknown-linux-gnueabihf": "29bf1726db3aa7a2327a4c14697b4e75",
+        "armv7-unknown-linux-gnueabihf": "fe64e5a640f8ba84cb7e38fd886c43f0",
+        "i686-unknown-linux-gnu": "63b539d1b5f918f0719013393617216a",
+        "x86_64-unknown-linux-gnu": "fddc2f90143ef477136a80b261e83ff6",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "f0ef0b9e75613725357f526cd7ac259aac1da37927a8d919eff3eafb8f5087a7",
+        "arm-unknown-linux-gnueabi": "9cfbd484b4ff759060f552d60c08cc3ac547d4369449cc14154474104a3b3b33",
+        "arm-unknown-linux-gnueabihf": "ed5c1d55aff32a78583f641540eceddf98ee7f5a6f26f0fec49b97f25b03d2d7",
+        "armv7-unknown-linux-gnueabihf": "3f4d3e00b72d35681c66158f5e2af85f07916c422dfce62c3d1bcd4c6245e8f1",
+        "i686-unknown-linux-gnu": "df6126fa404c9cd604f48aebc27f6d286957de282c96d84a6edc1c8129e7fd78",
+        "x86_64-unknown-linux-gnu": "78ad87102aebe101fb61d8fb6bb4b4da8674c57f0af810b3b3310f9f1a63d002",
+    }
+    return get_by_triple(HASHES, triple)
+
+def cargo_url(triple):
+    URLS = {
+        "aarch64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-10-05/cargo-1.73.0-aarch64-unknown-linux-gnu.tar.gz",
+        "arm-unknown-linux-gnueabi": "https://static.rust-lang.org/dist/2023-10-05/cargo-1.73.0-arm-unknown-linux-gnueabi.tar.gz",
+        "arm-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-10-05/cargo-1.73.0-arm-unknown-linux-gnueabihf.tar.gz",
+        "armv7-unknown-linux-gnueabihf": "https://static.rust-lang.org/dist/2023-10-05/cargo-1.73.0-armv7-unknown-linux-gnueabihf.tar.gz",
+        "i686-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-10-05/cargo-1.73.0-i686-unknown-linux-gnu.tar.gz",
+        "x86_64-unknown-linux-gnu": "https://static.rust-lang.org/dist/2023-10-05/cargo-1.73.0-x86_64-unknown-linux-gnu.tar.gz",
+    }
+    return get_by_triple(URLS, triple)
+
+DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.73.0)"
+
+LIC_FILES_CHKSUM = "\
+    file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
+    file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \
+"
+
+require cargo-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.71.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.71.1.bb
@@ -1,0 +1,69 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "c7aed8c93a2e1f123d4a577f51d39c90",
+        "aarch64-unknown-linux-musl": "3356681fd59ad10c8c0ab546d59ccf99",
+        "arm-unknown-linux-gnueabi": "2164ee0bc36327baf8c49ef039981d85",
+        "arm-unknown-linux-gnueabihf": "ce1e2aea1cfa6df849e5373b75372f2b",
+        "armv5te-unknown-linux-gnueabi": "c412959b22a2cb826839354e88464420",
+        "armv5te-unknown-linux-musleabi": "2ca9efc9b57581d7f09f4e58fe12c4d8",
+        "armv7-unknown-linux-gnueabihf": "5dc306d424327c09a95ffb6d49239514",
+        "armv7-unknown-linux-musleabihf": "55b187e789829bff81eea24de6076e10",
+        "i686-unknown-linux-gnu": "067e33e7d9f54fc3736c51f98fb42969",
+        "mips-unknown-linux-gnu": "bdb2339c981e1122ebb35dd6f6737014",
+        "mipsel-unknown-linux-gnu": "43b525a9e26870ac8129ac3a4ea99c27",
+        "powerpc-unknown-linux-gnu": "d57ff6baae4cc62ef99e5ed35c5efc1d",
+        "x86_64-unknown-linux-gnu": "66cdd65c8cedf15b3782334c304dbc4e",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "88572949b25b9c91e90507276a15a1c805548e444284ef8848a08a2897a806d6",
+        "aarch64-unknown-linux-musl": "7ef13898cfb19fb75125c6ca7392cdf1fce1c54f20c205d353f2d3763e5f7257",
+        "arm-unknown-linux-gnueabi": "f9f11a2e377be57974b6fd77c1948da2aa906504fd70ea25b41624e79e363326",
+        "arm-unknown-linux-gnueabihf": "15ee6917eef20f095ac06d436af0b02f207d455ac13525430daf6854c8b73a7a",
+        "armv5te-unknown-linux-gnueabi": "233d7b8375ab73233b0af69e89d5ed6456b0edaf6c4da1f29684c4bf5cb215ae",
+        "armv5te-unknown-linux-musleabi": "fb896cec2801c90541488f80963f37eace4a1d0923ab7d7db7990f48dd80b3ad",
+        "armv7-unknown-linux-gnueabihf": "6b5df36c1d28f64208de66384547bd3489a1bc1041ea17901530a758e558dd14",
+        "armv7-unknown-linux-musleabihf": "545cf1613d8ad4efd0d6c7cde21c2d15d1c8eca3e464d9f14db01323bb0220b5",
+        "i686-unknown-linux-gnu": "a5d4dc0317406c587e027f2586b77c5841fab5226716f51a441ac63a0acf3d0e",
+        "mips-unknown-linux-gnu": "ca6ec963222492215c3e490ef6d6d719074ed81e6a516b889c13b3fa5e6dceb5",
+        "mipsel-unknown-linux-gnu": "880d1cdc6d7360ea0adf45b37a7ca88a31175ebf5d819b7cd26606edd42250c2",
+        "powerpc-unknown-linux-gnu": "e5d4668148c6a72bc64daeff089c1c258371b4ea2ee5e3691c84f202f70a7a98",
+        "x86_64-unknown-linux-gnu": "2bbcfba62ad2d2cf05c53d91c578e5cce766d5308cd49a1e425139470282865e",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "476829c0b5a2cbe83cf207e36f483ef3",
+        "arm-unknown-linux-gnueabi": "efebdcfbb9f14c456d6efb19e5a54cde",
+        "arm-unknown-linux-gnueabihf": "a7b75ed71d1ed1147a7e81a11373e13c",
+        "armv7-unknown-linux-gnueabihf": "2f3a58ae9d10735e5a20245ccfd74abf",
+        "i686-unknown-linux-gnu": "832b291e6152bb9f02649211eeda1731",
+        "x86_64-unknown-linux-gnu": "b5a094666e308918c2b9dfaca255b83b",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "c0931d12e28c330490aaa6ba68a3b30b1d69aa004e5d1d203a653910c88e1769",
+        "arm-unknown-linux-gnueabi": "ae7181c6d0ea5852b9f38214e15ad78d8f92808e67048b3523130601c94e09ce",
+        "arm-unknown-linux-gnueabihf": "ce5c3ae7b6a948aefb83bdecc7f78421b7e7b377e34f490f98df6fa120e97f84",
+        "armv7-unknown-linux-gnueabihf": "f458b83bc6a863d43fb481254d7c13abe56c3ff7539ddc890fc041a5097c2c35",
+        "i686-unknown-linux-gnu": "3d95bf5890772b883f590c73ce76030df3b5bc90e106cf8597cdfda83c8f229d",
+        "x86_64-unknown-linux-gnu": "e3f557972600d26cb885d0ae34e0208722eec5a59cc364bfac68f5ca49536d90",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.72.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.72.0.bb
@@ -1,0 +1,65 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "13a647b3b670f914259590cb180ccf7a",
+        "aarch64-unknown-linux-musl": "5709ae8979c13b488b8db5da684ca280",
+        "arm-unknown-linux-gnueabi": "4d828960e631d47d8c48b61894c2d65c",
+        "arm-unknown-linux-gnueabihf": "51768b064cf1f55dd5e78717786c5875",
+        "armv5te-unknown-linux-gnueabi": "7e88e98f246894d37606ba2588976045",
+        "armv5te-unknown-linux-musleabi": "68d81093d0c2ea6faf245ed71bd9a4b2",
+        "armv7-unknown-linux-gnueabihf": "7a955d4a3d0c5e9e9ca509fb6aa78af1",
+        "armv7-unknown-linux-musleabihf": "43a978185853469505aa74099f2dbf18",
+        "i686-unknown-linux-gnu": "aca6c601c083599e8b120c913a78dd7e",
+        "powerpc-unknown-linux-gnu": "ffeb18c944d8789d627f7054fde5118e",
+        "x86_64-unknown-linux-gnu": "336857bf48bc1fab0073893b272b56a3",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "dd504733d3d8939b448ee93247d62d7fb09316b54c2f247b3c9f4709bf70784d",
+        "aarch64-unknown-linux-musl": "d560f26d20708f4073d40190abe17d119852f991a17182a6a2cbc53a4c0c5da4",
+        "arm-unknown-linux-gnueabi": "f54d9a863354d5003013fd786c85ca08590141c40f13a939ac451920545ae749",
+        "arm-unknown-linux-gnueabihf": "44eaed1b11e16cbfd6a713c686fcaddf2cbb447744594267068a04fdea321080",
+        "armv5te-unknown-linux-gnueabi": "6dd09cbf767daba265c50d1885a3edbaa2a153a85ee487fda2eb5290e0d2f4fc",
+        "armv5te-unknown-linux-musleabi": "60d3892060653e656a8268a2fadeb3a911e70d04f9059475d7c4b7c67755e623",
+        "armv7-unknown-linux-gnueabihf": "ae5ee9aee53e1248746aa24d993a85e38662c17777982e7cd8925e1953a699cc",
+        "armv7-unknown-linux-musleabihf": "e1e504dc7f15fb60f83ce836d6c420f807a9037312f335fb1a1bcc2c5c150610",
+        "i686-unknown-linux-gnu": "75708e4e4d01a3106f6d84be1a70b22405f57cc04ae1390c3604e74fe957011e",
+        "powerpc-unknown-linux-gnu": "8db8bda10b87e6717ac90e78cc5ccdcb8f5c3d8c6a3b9cd5016df836784dd6e0",
+        "x86_64-unknown-linux-gnu": "89f6f6ef25e7e754940c54cc0584bfdb83e1df75019d5aa126e3fa66c2921b15",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "f08ba1672fa18d9bc5b8b679dabb8023",
+        "arm-unknown-linux-gnueabi": "b6e9dc272fdedfc964eb4083e39b1714",
+        "arm-unknown-linux-gnueabihf": "e2172af00d86735b10a3bf8e302f4541",
+        "armv7-unknown-linux-gnueabihf": "7f141138729cec74eed15ad210969932",
+        "i686-unknown-linux-gnu": "f220119f16dcfd7785812f05e30a427b",
+        "x86_64-unknown-linux-gnu": "b2f3b7bb99e8220877f4080fed2534ba",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "3a2d1a5b5b713615162dcaa6319b6ad65ab4b951f90557dfb1e5c54f2a64c4ee",
+        "arm-unknown-linux-gnueabi": "130bb74b4baa3d55182f6bcae1d8cf5ef3004f410d9ad2fc81787590e81da973",
+        "arm-unknown-linux-gnueabihf": "4eb145d9a0240963e001933c7173f9c7222c6fc872570194e7a0484fe377bbe9",
+        "armv7-unknown-linux-gnueabihf": "c73e4bf09478b4176d66f166b78ba5b08e87991b43f337ba07748cc86188bdb2",
+        "i686-unknown-linux-gnu": "0c6adfe6c06b66fea2ecbf7e3e47a9375bd6c32d9e34c050d0bf03ba685abda4",
+        "x86_64-unknown-linux-gnu": "f414557b12f2a7a61fabf152b4b9d6cb436ff15698e64a3111bca1a94be97a3e",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.72.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.72.1.bb
@@ -1,0 +1,65 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "fd224bd6acbbde07881647287c3944c4",
+        "aarch64-unknown-linux-musl": "9a8151d9c632c36d2110332492abf343",
+        "arm-unknown-linux-gnueabi": "8aa5ccf84a037ee7703058b8ba0770d8",
+        "arm-unknown-linux-gnueabihf": "6ef1add42486946a621e71114c14a383",
+        "armv5te-unknown-linux-gnueabi": "53fd441d3dcc66fac08cf3882e4b9054",
+        "armv5te-unknown-linux-musleabi": "76332e25a6c804fbd7f5628aa4a96399",
+        "armv7-unknown-linux-gnueabihf": "cc35f38c9c20ae3a122bc572202cfb6f",
+        "armv7-unknown-linux-musleabihf": "7b9680560c70e7a664a488b23a067b4f",
+        "i686-unknown-linux-gnu": "8e00b1171a851ffc5d4cf534ba40d647",
+        "powerpc-unknown-linux-gnu": "f0db96c1546ff0f07d02cc98d0b2c2fe",
+        "x86_64-unknown-linux-gnu": "bb20a9de56624b1cfb74b6559427f6ee",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "7c43a6f56b100ce929967ef0d34fa316e0c4b233cb3ba84db67832135006c403",
+        "aarch64-unknown-linux-musl": "a817c49da05ce0c6ec033c0f9228ba7886ae36ef901c2c3c040b60367c89bcbd",
+        "arm-unknown-linux-gnueabi": "258aa5bd91e356a8304d83218a067d35e6de12606e565f405b22418c6300c8c5",
+        "arm-unknown-linux-gnueabihf": "db33eff5bf068c0f087315b071f52d2fc30d5ab93cfae606e27341cd34e681f2",
+        "armv5te-unknown-linux-gnueabi": "a900c058894e1168bca40ce8ee21b29474dc03ec5b29bf23fad5e06c86e7bf1b",
+        "armv5te-unknown-linux-musleabi": "026b23aa6d26db51aea54646b9adfcabd4e45204eadd3f00240ea5ea9440748a",
+        "armv7-unknown-linux-gnueabihf": "06c5dfc4e19cf743947e5da2682c548b53d99ebec0296070223827ce7636aec0",
+        "armv7-unknown-linux-musleabihf": "87e20ebb58bb1a3c255c8efaee05a23539f360a88d65ec8a7d29fae57454b537",
+        "i686-unknown-linux-gnu": "e53a82e2dbd9af74c3e91583ce8fe5911907f7f86f57f7e15c1f633a0dc44c1b",
+        "powerpc-unknown-linux-gnu": "0c727140589d214dd7a1616776f1ab9718025065e61c32f199f62d91b68e8419",
+        "x86_64-unknown-linux-gnu": "d5d3751b4558864fd95f17b1b6eaeff3130a3de1a6920750a3b8c6b0fa03fb1c",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "2d38c96dece95a01f129ead973113d29",
+        "arm-unknown-linux-gnueabi": "619d3d084e3a8e611c201cea3712892a",
+        "arm-unknown-linux-gnueabihf": "a079f3c8a18b8787b8c2758ca9fc96c6",
+        "armv7-unknown-linux-gnueabihf": "f93c8e17962cb80bcc05a8028dbdf1c6",
+        "i686-unknown-linux-gnu": "de10495a50eb0cf31bbca3fd7c6c8042",
+        "x86_64-unknown-linux-gnu": "3fd6e3edc52614e9a1cf53452a32afdb",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "04d75869d1c0f01e365d5d579456a81e817ed97463b70e7c273d031c48d2838b",
+        "arm-unknown-linux-gnueabi": "dc0f9c87f4f95de3945f40d44551f7d0e259bfa67d442f72eb24d395d6a9c634",
+        "arm-unknown-linux-gnueabihf": "107c51bfe1611b84dac87c348c9dd9635e8502a1db58fa935caf8d046b653706",
+        "armv7-unknown-linux-gnueabihf": "3aaf248d59af49f8851eb6d3ff07abbf9bdfbe222092a4b08b9f95486d8537d7",
+        "i686-unknown-linux-gnu": "064c2b155162d36b4fa0655207fba8315962dc72840704155494cb71e48a59c5",
+        "x86_64-unknown-linux-gnu": "9cf84e4de7302644e8c68b8d2abf6ac9e2b56409c3fa5b2ab95168bfaa5c562d",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+require rust-bin-cross.inc

--- a/recipes-devtools/rust/rust-bin-cross_1.73.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.73.0.bb
@@ -1,0 +1,65 @@
+
+def get_by_triple(hashes, triple):
+    try:
+        return hashes[triple]
+    except:
+        raise bb.parse.SkipRecipe("Unsupported triple: %s" % triple)
+
+
+def rust_std_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "7bed58c1095730738aea79f45f3e557a",
+        "aarch64-unknown-linux-musl": "0d59b0688eb926bdc8d4867e5085b06c",
+        "arm-unknown-linux-gnueabi": "acda32f6a52fbc3fd8b1a66c73be8d6f",
+        "arm-unknown-linux-gnueabihf": "56ab5622fb348f078499117a2cb457fe",
+        "armv5te-unknown-linux-gnueabi": "dea7efc9134683d1455879a8133faf57",
+        "armv5te-unknown-linux-musleabi": "48e34f833aa2ce2f063741b4dcb03aab",
+        "armv7-unknown-linux-gnueabihf": "7422b99882d0bd1f09cb0d95abd14c9b",
+        "armv7-unknown-linux-musleabihf": "70f0b9a8b6756c66320d5bb216970348",
+        "i686-unknown-linux-gnu": "2fa1545cebfad35bce4ac9772f399830",
+        "powerpc-unknown-linux-gnu": "28a5c267b8606a31e0d3a23306e38118",
+        "x86_64-unknown-linux-gnu": "b687e1e8c08d4cf88065d271a75dc633",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rust_std_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "47f2f904befca10a5f6dd68271a343b3700e651c67e25e723d4a4a0e2b4e445b",
+        "aarch64-unknown-linux-musl": "ea4a46131c39b27a4d8a74e3ee0d63a70df7995683828f87fad08fccf5592fd8",
+        "arm-unknown-linux-gnueabi": "00b26559bff1532b8c2a2adf9f39447f0d40ee18152382d01dc77a8bbf1a9bad",
+        "arm-unknown-linux-gnueabihf": "4f2e613aba4053abf0d3e519bc366420922dc48b175f6d30ee449355ca2a786f",
+        "armv5te-unknown-linux-gnueabi": "0819db0eb290d52c1c2329a81120bf9c903af14467694c250c5f1051be2faf0d",
+        "armv5te-unknown-linux-musleabi": "c0aa0452a3ccdc6eab70b4e6f09a00fae1ae8c205c21d68607d8c70319403ce8",
+        "armv7-unknown-linux-gnueabihf": "d6b645f127517c9553af2eeb919e120a59d84b2b035334a11a734f2ddc7775ca",
+        "armv7-unknown-linux-musleabihf": "b314174907b4f4127e61f8c61580be4dcdd8354dff471c39d6e3573742142402",
+        "i686-unknown-linux-gnu": "75f92f0e33c6724cb1876625289126fcf2d101fc6e30ab5a34309e618d6e06a5",
+        "powerpc-unknown-linux-gnu": "49692419b05e82adf1099ebc17468f9bc3d411f5d42d39ec77c13473f2b5ea2c",
+        "x86_64-unknown-linux-gnu": "9e941972c8679c2d852addf979455afd61e3ec33000cbc2421b162bcb05897a6",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_md5(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "2b2d0d20dcc5023f4c1d6030a893a7cb",
+        "arm-unknown-linux-gnueabi": "bc5650cd946f0d252c82e86f54495e7a",
+        "arm-unknown-linux-gnueabihf": "37bf53bcdd26b84b91200842784f92bc",
+        "armv7-unknown-linux-gnueabihf": "21d4bd26fd8b50fd3c92d1b2a8b89a40",
+        "i686-unknown-linux-gnu": "bd27cc2e136e6422fa80430a579f2db5",
+        "x86_64-unknown-linux-gnu": "b177e99c118cce783f1916ed620db55e",
+    }
+    return get_by_triple(HASHES, triple)
+
+def rustc_sha256(triple):
+    HASHES = {
+        "aarch64-unknown-linux-gnu": "5f7141617b833f84a279b19e7c349b95e839d924e2a3ed3ae545b2d4ab55ce05",
+        "arm-unknown-linux-gnueabi": "099d9511c34f062b0db7614fa23af1552d2ecabcbe58e31c32bc329529d7088f",
+        "arm-unknown-linux-gnueabihf": "9f6eb085a1795cf897b831e5c507b126fead0e5286e524307112a92942b84aa8",
+        "armv7-unknown-linux-gnueabihf": "31ba70b4cefeccf2a2300fc46fbfd3fc1c82239e483161da5c840f5130df9d65",
+        "i686-unknown-linux-gnu": "5399791a11a3d8617f680f02fc7f1c14fba1a0d27a1cc3a256e31678853763a1",
+        "x86_64-unknown-linux-gnu": "31be7397a8a70fcb48e119925c9ff05554e2094140889ef9760b70a724d56346",
+    }
+    return get_by_triple(HASHES, triple)
+
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=c2cccf560306876da3913d79062a54b9"
+
+require rust-bin-cross.inc


### PR DESCRIPTION
Add recipes for Rust versions from v1.71.1 to v1.73.0.

_Note_
v1.71.1 does include `mips-unknown-linux-gnu` and `mipsel-unknown-linux-gnu` (See #145)