### PR TITLE
Adjust the settings to compile Rust programs in debug mode by default

### DIFF
--- a/classes/cargo_bin.bbclass
+++ b/classes/cargo_bin.bbclass
@@ -29,7 +29,7 @@ RUSTFLAGS += "${EXTRA_RUSTFLAGS}"
 CARGO_FEATURES ??= ""
 
 # Control the Cargo build type (debug or release)
-# CARGO_BUILD_TYPE ?= "--release"
+CARGO_BUILD_TYPE ?= ""
 
 CARGO_INSTALL_DIR ?= "${D}${bindir}"
 

--- a/classes/cargo_bin.bbclass
+++ b/classes/cargo_bin.bbclass
@@ -29,7 +29,7 @@ RUSTFLAGS += "${EXTRA_RUSTFLAGS}"
 CARGO_FEATURES ??= ""
 
 # Control the Cargo build type (debug or release)
-CARGO_BUILD_TYPE ?= "--release"
+# CARGO_BUILD_TYPE ?= "--release"
 
 CARGO_INSTALL_DIR ?= "${D}${bindir}"
 


### PR DESCRIPTION
Bitbake reports a QA error indicating that the binary files have already been stripped. The requirement is for the produced binary files to remain unstripped
It solves issue of QA Error of strip image #159
