### PR TITLE
Remove specific rust version from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ dependencies as well as default compile and install steps.
 
 Currently supported:
 
-  * Rust 1.74.0 (and many older, stable versions)
+  * Current stable rust release (usually shortly after release) and several
+    previous releases, see [the versioned recipes](./recipes-devtools/rust/).
   * x86 (32 and 64-bit), ARM (32 and 64-bit) build systems.
   * All Linux architectures that Rust itself supports (Multiple flavors of:
     x86, ARM, PPC, and MIPS)


### PR DESCRIPTION
We have automation around creating the new recipe bump.  Having documentation around the current latest version tends to get missed, so this change drops it in favor of just informing users of where to look to confirm which versions are supported in tree.

See discussion in https://github.com/rust-embedded/meta-rust-bin/pull/164#issuecomment-1936795903, CC @cordahi