### PR TITLE
correctly handle dev, bench, test profiles

### DIFF
--- a/classes/cargo_bin.bbclass
+++ b/classes/cargo_bin.bbclass
@@ -33,7 +33,17 @@ CARGO_BUILD_PROFILE ?= "release"
 
 CARGO_INSTALL_DIR ?= "${D}${bindir}"
 
-CARGO_BINDIR = "${B}/${RUST_TARGET}/${CARGO_BUILD_PROFILE}"
+def cargo_profile_to_builddir(profile):
+    # See https://doc.rust-lang.org/cargo/guide/build-cache.html
+    # for the special cases mapped here.
+    return {
+        'dev': 'debug',
+        'test': 'debug',
+        'release': 'release',
+        'bench': 'release',
+    }.get(profile, profile)
+
+CARGO_BINDIR = "${B}/${RUST_TARGET}/${@cargo_profile_to_builddir(d.getVar('CARGO_BUILD_PROFILE'))}"
 WRAPPER_DIR = "${WORKDIR}/wrappers"
 
 # Set the Cargo manifest path to the typical location


### PR DESCRIPTION
From https://doc.rust-lang.org/cargo/guide/build-cache.html

> For historical reasons, the dev and test profiles are stored in the
> debug directory, and the release and bench profiles are stored in the
> release directory. User-defined profiles are stored in a directory with
> the same name as the profile.

Fixes #167, CC @DavidAntliff