### PR TITLE
Ignore string case when checking ARCH, OS, and TUNE variables

### DIFF
--- a/classes/rust_bin-common.bbclass
+++ b/classes/rust_bin-common.bbclass
@@ -6,8 +6,8 @@ def rust_target(d, spec_type):
     import re
     spec_type = spec_type.upper()
 
-    arch = d.getVar('%s_ARCH' % spec_type, True)
-    os = d.getVar('%s_OS' % spec_type, True)
+    arch = d.getVar('%s_ARCH' % spec_type, True).lower()
+    os = d.getVar('%s_OS' % spec_type, True).lower()
 
     # Make sure that tasks properly recalculate after ARCH or OS change
     d.appendVarFlag("rust_target", "vardeps", " %s_ARCH" % spec_type)
@@ -36,8 +36,8 @@ def rust_target(d, spec_type):
 
     # TUNE_FEATURES are always only for the TARGET
     if spec_type == "TARGET":
-        tune = d.getVar("TUNE_FEATURES", True).split()
-        tune += d.getVar("MACHINEOVERRIDES", True).split(":")
+        tune = d.getVar("TUNE_FEATURES", True).lower().split()
+        tune += d.getVar("MACHINEOVERRIDES", True).lower().split(":")
     else:
         tune = []
 


### PR DESCRIPTION
When checking that we're targeting a valid architecture and OS there is an unintentional case-sensitive test. So the OS 'Linux' is not accepted, it'd have to be 'linux'.

I fixed this up by making the OS, arch, and tune parameter checks case-insensitive.

See https://github.com/rust-embedded/meta-rust-bin/issues/171