### PR TITLE
Fix CC pointing to wrong compiler

### DIFF
--- a/classes/cargo_bin.bbclass
+++ b/classes/cargo_bin.bbclass
@@ -101,7 +101,7 @@ cargo_bin_do_compile() {
     export BUILD_CC="${WRAPPER_DIR}/cc-native-wrapper.sh"
     export BUILD_CXX="${WRAPPER_DIR}/cxx-native-wrapper.sh"
     export TARGET_LD="${WRAPPER_DIR}/linker-wrapper.sh"
-    export LD="${WRAPPER_DIR}/linker-native-wrapper.sh"
+    export LD="${WRAPPER_DIR}/linker-wrapper.sh"
     export PKG_CONFIG_ALLOW_CROSS="1"
     export LDFLAGS=""
     export RUSTFLAGS="${RUSTFLAGS}"

--- a/classes/cargo_bin.bbclass
+++ b/classes/cargo_bin.bbclass
@@ -96,8 +96,10 @@ cargo_bin_do_configure() {
 cargo_bin_do_compile() {
     export TARGET_CC="${WRAPPER_DIR}/cc-wrapper.sh"
     export TARGET_CXX="${WRAPPER_DIR}/cxx-wrapper.sh"
-    export CC="${WRAPPER_DIR}/cc-native-wrapper.sh"
-    export CXX="${WRAPPER_DIR}/cxx-native-wrapper.sh"
+    export CC="${WRAPPER_DIR}/cc-wrapper.sh"
+    export CXX="${WRAPPER_DIR}/cxx-wrapper.sh"
+    export BUILD_CC="${WRAPPER_DIR}/cc-native-wrapper.sh"
+    export BUILD_CXX="${WRAPPER_DIR}/cxx-native-wrapper.sh"
     export TARGET_LD="${WRAPPER_DIR}/linker-wrapper.sh"
     export LD="${WRAPPER_DIR}/linker-native-wrapper.sh"
     export PKG_CONFIG_ALLOW_CROSS="1"


### PR DESCRIPTION
Hi,

Thanks for this project :)

I encountered an issue when trying to cross compile [vector](https://github.com/vectordotdev/vector) using Yocto Scarthgap for an aarch64 platform (e.g. Raspberry Pi 4) : 

```
| error: failed to run custom build command for `krb5-src v0.3.2+1.19.2`
| 
| Caused by:
|   process didn't exit successfully: `/workspaces/omnios_rust_bin/build/tmp/work/cortexa72-poky-linux/vector/0.44.0/target/release/build/krb5-src-7d691da815ca739d/build-script-build` (exit status: 101)
|   --- stdout
|   checking for aarch64-unknown-linux-gnu-gcc... /workspaces/omnios_rust_bin/build/tmp/work/cortexa72-poky-linux/vector/0.44.0/wrappers/cc-native-wrapper.sh
|   checking whether the C compiler works... no
| 
|   --- stderr
|   configure: error: in `/workspaces/omnios_rust_bin/build/tmp/work/cortexa72-poky-linux/vector/0.44.0/target/aarch64-unknown-linux-gnu/release/build/krb5-src-7712872c0cb50834/out/build':
|   configure: error: C compiler cannot create executables
```

By the look of it the build system was trying to use the gcc from the host (in my case it's running in Docker but that's irrelevant) and was therefore failing. I have changed the values set in `CC` and `CXX` to match what is done in `cargo_bin_do_configure` : 
```
echo "${CC} \"\$@\"" >>"${WRAPPER_DIR}/cc-wrapper.sh"
echo "${CXX} \"\$@\"" >>"${WRAPPER_DIR}/cxx-wrapper.sh"
```

And with this the build is successful. 

Please let me know if this is not the right approach.

Thanks,
Antoine
