### PR TITLE
classes/rust_bin-common: avoid failing when os does not match

### DIFF
--- a/classes/rust_bin-common.bbclass
+++ b/classes/rust_bin-common.bbclass
@@ -42,7 +42,7 @@ def rust_target(d, spec_type):
         tune = []
 
     if not os == 'linux':
-        bb.fatal("Unsupported OS: %s. Only Linux is supported." % os)
+        raise bb.parse.SkipRecipe("Unsupported OS: %s. Only Linux is supported." % os)
 
     if arch in ["i386", "i486", "i586", "i686", "i786", "x86"]:
         arch = "i686"


### PR DESCRIPTION
The rust_bin-common defines rust_target(), a function called at parsing time by bitbake. Calling bb.fatal() in a multiconfig context builds is problematic, because the alternate config might not build for Linux. For example when building a baremetal companion firmware.

Yet, our multiconfig recipes are still evaluated during parsing, and in this case, it makes more sense skipping the recipe rather than producing an error. Use bb.parse.SkipRecipe() instead of bb.fatal().

---

This can be easily reproduced by trying to build with meta-rust-bin and the `beagleplay` machine in the [meta-ti-bsp](https://git.yoctoproject.org/meta-ti/tree/meta-ti-bsp) layer. The multiconfig build ([k3r5](https://git.yoctoproject.org/meta-ti/tree/meta-ti-bsp/conf/multiconfig/k3r5.conf)) will trigger hundreds of errors.