### PR TITLE
Fix use in multi-config builds that don't target glibc

### DIFF
--- a/classes/rust_bin-common.bbclass
+++ b/classes/rust_bin-common.bbclass
@@ -42,7 +42,7 @@ def rust_target(d, spec_type):
         tune = []
 
     if not os == 'linux':
-        bb.fatal("Unsupported OS: %s. Only Linux is supported." % os)
+        raise bb.parse.SkipRecipe("Unsupported OS: %s. Only Linux is supported." % os)
 
     if arch in ["i386", "i486", "i586", "i686", "i786", "x86"]:
         arch = "i686"


### PR DESCRIPTION
Building for a BeaglePlay with meta-ti yields a multi-config build, where some of the images built are for the regular (glibc) based Linux, and some images are for bare-metal environment.

In that bare-metal environment, TARGET_OS is set to "eabi":

    meta/conf/distro/include/tclibc-baremetal.inc:TARGET_OS:arm = "eabi"

This makes meta-rust-bin abort fatally.

This patch proposes a more graceful handling by skipping such recipes, instead of aborting the entire build, including the images where TARGET_OS is set to Linux. This also appears to be inline with how other recipes in oe-core handle this.