### PR TITLE
Fix cc wrappers (revert #197)

### DIFF
--- a/classes/cargo_bin.bbclass
+++ b/classes/cargo_bin.bbclass
@@ -96,10 +96,8 @@ cargo_bin_do_configure() {
 cargo_bin_do_compile() {
     export TARGET_CC="${WRAPPER_DIR}/cc-wrapper.sh"
     export TARGET_CXX="${WRAPPER_DIR}/cxx-wrapper.sh"
-    export CC="${WRAPPER_DIR}/cc-wrapper.sh"
-    export CXX="${WRAPPER_DIR}/cxx-wrapper.sh"
-    export BUILD_CC="${WRAPPER_DIR}/cc-native-wrapper.sh"
-    export BUILD_CXX="${WRAPPER_DIR}/cxx-native-wrapper.sh"
+    export CC="${WRAPPER_DIR}/cc-native-wrapper.sh"
+    export CXX="${WRAPPER_DIR}/cxx-native-wrapper.sh"
     export TARGET_LD="${WRAPPER_DIR}/linker-wrapper.sh"
     export LD="${WRAPPER_DIR}/linker-wrapper.sh"
     export PKG_CONFIG_ALLOW_CROSS="1"

--- a/classes/cargo_bin.bbclass
+++ b/classes/cargo_bin.bbclass
@@ -99,7 +99,7 @@ cargo_bin_do_compile() {
     export CC="${WRAPPER_DIR}/cc-native-wrapper.sh"
     export CXX="${WRAPPER_DIR}/cxx-native-wrapper.sh"
     export TARGET_LD="${WRAPPER_DIR}/linker-wrapper.sh"
-    export LD="${WRAPPER_DIR}/linker-wrapper.sh"
+    export LD="${WRAPPER_DIR}/linker-native-wrapper.sh"
     export PKG_CONFIG_ALLOW_CROSS="1"
     export LDFLAGS=""
     export RUSTFLAGS="${RUSTFLAGS}"


### PR DESCRIPTION
If I'm not mistaken, the changes made in pull request #197 break some rust build scripts.

The behavior as it originally was should have been correct, as it defines 

```
CC="${WRAPPER_DIR}/cc-native-wrapper.sh"    # this is used when building on the host, as long as `HOST_CC` is not defined, and therefore it should point to cc-native-wrapper.sh
TARGET_CC="${WRAPPER_DIR}/cc-wrapper.sh"
```

According to the `cc` [docs](https://docs.rs/cc/1.2.21/cc/), `TARGET_CC` takes precedence over `CC` when cross-compiling to the target, and otherwise `CC` is being used.

In addition, the original pull request defined the variable  `BUILD_CC`, but that is meaningless for the `cc` crate (Yocto defines such a [variable](https://docs.yoctoproject.org/ref-manual/variables.html#term-BUILD_CC), but `cc` only looks for `HOST_CC` and `CC` when compiling for the host).

I think this should also fix #204

I'm not sure what the original problem was which pull request #197 tried to solve, but maybe there was just no adequate `gcc` installed on the host system?