### PR TITLE
Add wasm32-unknown-unknown as a support rust-std arch

### DIFF
--- a/build-new-version.sh
+++ b/build-new-version.sh
@@ -36,6 +36,7 @@ TARGET_TRIPLES=(
     x86_64-unknown-linux-gnu
     riscv64gc-unknown-linux-gnu
     thumbv7neon-unknown-linux-gnueabihf
+    wasm32-unknown-unknown
 )
 
 RUSTC_TRIPLES=(

--- a/recipes-devtools/rust/cargo-bin-cross_1.57.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.57.0.bb
@@ -42,6 +42,7 @@ def cargo_url(triple):
     return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.57.0)"
+
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
     file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \

--- a/recipes-devtools/rust/cargo-bin-cross_1.58.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.58.1.bb
@@ -42,6 +42,7 @@ def cargo_url(triple):
     return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.58.1)"
+
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
     file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \

--- a/recipes-devtools/rust/cargo-bin-cross_1.59.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.59.0.bb
@@ -42,6 +42,7 @@ def cargo_url(triple):
     return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.59.0)"
+
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
     file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \

--- a/recipes-devtools/rust/cargo-bin-cross_1.60.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.60.0.bb
@@ -42,6 +42,7 @@ def cargo_url(triple):
     return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.60.0)"
+
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
     file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \

--- a/recipes-devtools/rust/cargo-bin-cross_1.61.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.61.0.bb
@@ -42,6 +42,7 @@ def cargo_url(triple):
     return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.61.0)"
+
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
     file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \

--- a/recipes-devtools/rust/cargo-bin-cross_1.62.1.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.62.1.bb
@@ -42,6 +42,7 @@ def cargo_url(triple):
     return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.62.1)"
+
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
     file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \

--- a/recipes-devtools/rust/cargo-bin-cross_1.63.0.bb
+++ b/recipes-devtools/rust/cargo-bin-cross_1.63.0.bb
@@ -42,6 +42,7 @@ def cargo_url(triple):
     return get_by_triple(URLS, triple)
 
 DEPENDS += "rust-bin-cross-${TARGET_ARCH} (= 1.63.0)"
+
 LIC_FILES_CHKSUM = "\
     file://LICENSE-APACHE;md5=71b224ca933f0676e26d5c2e2271331c \
     file://LICENSE-MIT;md5=b377b220f43d747efdec40d69fcaa69d \

--- a/recipes-devtools/rust/rust-bin-cross_1.57.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.57.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "f8b3f417020c7fe2d0a92813b01266d6",
         "armv7-unknown-linux-musleabihf": "1629c470b5542de876623dbce040c433",
         "i686-unknown-linux-gnu": "1a89ae5f276a4bce1d21f7ad7546f094",
-        "mips-unknown-linux-gnu": "a2862f3bb10112728b3dd700c3a27a23",
-        "mipsel-unknown-linux-gnu": "5076bddb96fc9649e2059ce0074217e5",
         "powerpc-unknown-linux-gnu": "59216f57de54e1cd149bf51ca7c11ac6",
         "x86_64-unknown-linux-gnu": "a8f43a2f5563c13820473b2f1059c144",
+        "riscv64gc-unknown-linux-gnu": "772e545365d5904fc7b051b6bb5e791a",
+        "thumbv7neon-unknown-linux-gnueabihf": "300797483cbfe96b189f09c04d6300ed",
+        "wasm32-unknown-unknown": "18fb36ac4c2ed41bd45cf6242bdad06b",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "39b170358cf76c6dc284cf2c99439338871b79f5d0417f3342d48694c392121d",
         "armv7-unknown-linux-musleabihf": "0c3917cb3e166fc1f3dbb945893199a12e578df32f02c70c9bce1cda7d968c1a",
         "i686-unknown-linux-gnu": "6fb3eb0e9f401d568a3da52c7cd26dadfcd6f1ebd4bc25075b5a092e51e230c9",
-        "mips-unknown-linux-gnu": "f4c3dadfdf03b5261a1eba2ccf382f99ef6f6177a4ee2d9f19174df6f2d81db4",
-        "mipsel-unknown-linux-gnu": "c10e699fc22f673d8c91a4aad3e4e78ca60f91485936a093595f0ea90b5399c1",
         "powerpc-unknown-linux-gnu": "dc70b13f3cd8bf6eab0d619a5e0113b071b070d06cb0bacec0e0632e09a3c5cc",
         "x86_64-unknown-linux-gnu": "9140ad6f46a903345d4297a987ccaf37b9c5ca594cd6fd5a27d0be482116fe7f",
+        "riscv64gc-unknown-linux-gnu": "ab549d4b6ac630abb96e2739f36f2165816efdd0bbba5982a827953886ab2531",
+        "thumbv7neon-unknown-linux-gnueabihf": "03e596499c02298a6633afaf942a6efc2358730bdf1bed71fa2a23e6d45466af",
+        "wasm32-unknown-unknown": "3e0525d9e16f1a58e847080f2d3c02e275c2d5563b7980311e39382bb6c8441d",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.58.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.58.1.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "294364a35b349256986e77da783ac46b",
         "armv7-unknown-linux-musleabihf": "d3422c3a8a704365a0946b2b93a7f901",
         "i686-unknown-linux-gnu": "bb3f87ec834d66375f5f21fb3892d10c",
-        "mips-unknown-linux-gnu": "05ae6607aacef3d5392de7e07a6dbc1e",
-        "mipsel-unknown-linux-gnu": "84b6f2fbc582e467156a60e2e2f7cad4",
         "powerpc-unknown-linux-gnu": "302d9b9ea97360c038ad1ad7d54ed0b2",
         "x86_64-unknown-linux-gnu": "61132498f4526e5390b027b3994f769f",
+        "riscv64gc-unknown-linux-gnu": "9b2c09e0dfa6874936846922b97c9f69",
+        "thumbv7neon-unknown-linux-gnueabihf": "aff1c70b17eee967b1218bf37c1ce558",
+        "wasm32-unknown-unknown": "4ccc95a26751eae57c34ddded578ca82",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "5cea8641145397b42f088b369cc59b991d96937b3f7f4204fb9fec73247ca008",
         "armv7-unknown-linux-musleabihf": "77672d915e5981e6a9e4d6820eeb051af38519f95035665ae75fb3bdc042d11a",
         "i686-unknown-linux-gnu": "e6c8486886e13f47d99e1cd9bc941a75aa149936fcc6ad3cc6ab2e32cb8a7641",
-        "mips-unknown-linux-gnu": "1c264ec6c7e3e7832b2538c31c23b1c03df9721b7fba4ae00804a36554fa4008",
-        "mipsel-unknown-linux-gnu": "83f2a67d893556367a4cab5baa134e786ca728eb9786ca96246ab03273862759",
         "powerpc-unknown-linux-gnu": "83587c6c2d49ae13c4ac35c73582c190834a72faf605fbf657c437313a2ededf",
         "x86_64-unknown-linux-gnu": "649bda48542f211d77afab4b71505572a4712b6b5c5bdee94533e2e7a9a832f1",
+        "riscv64gc-unknown-linux-gnu": "07746a0c64c65a913f4552d845175c4f007059ba09974c914d96b789a465eb61",
+        "thumbv7neon-unknown-linux-gnueabihf": "a2ebfccc9bb1c01f00f8fd52ebe8736ed8189dd374d7494ab42d3f24b7856a73",
+        "wasm32-unknown-unknown": "ef92a50952a03111c59745b8732f55f209da12e5dd8cd15072ad4ed96ad048e7",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.59.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.59.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "6d95e36897a970bcb616e67ac1e7b36b",
         "armv7-unknown-linux-musleabihf": "752011663a41fcf84aad2143eda56a1f",
         "i686-unknown-linux-gnu": "c2f9f27ab8069eb38d8eea014912efed",
-        "mips-unknown-linux-gnu": "574b6a671275cff6053008eea4bb7af3",
-        "mipsel-unknown-linux-gnu": "71d0540f4aac0e519680f2b6d4709b38",
         "powerpc-unknown-linux-gnu": "14e9875d79781fb3b03ce51e969e182d",
         "x86_64-unknown-linux-gnu": "bbb80d3b60091cc5d6328ef6b0d49440",
+        "riscv64gc-unknown-linux-gnu": "654079f6e9848ad2fc38bec852a1c7f9",
+        "thumbv7neon-unknown-linux-gnueabihf": "8e3120c0ac83d675dd08634efb91e675",
+        "wasm32-unknown-unknown": "c13448e0b6c2354fd8b678fe1d2c77d0",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "ac4c1758db6001179faebe210a7d2bd1beacf3998d690d0957a5412728763c45",
         "armv7-unknown-linux-musleabihf": "282586b053bf60cf21bb9a6275edc699bf3a9861cafeb378ce20e94d431a12fc",
         "i686-unknown-linux-gnu": "8a2f0f36b4d2146e044fd6253db24f86319c2109f54b34d708cf25f754778d73",
-        "mips-unknown-linux-gnu": "04b223dff64c134b752fb00f112296f84fca83865f2a459e065bba0c93f299f2",
-        "mipsel-unknown-linux-gnu": "79ff7848b12620347001c6aac5f4b8e2059ced4b6b8177f26b9d7be7b18f9547",
         "powerpc-unknown-linux-gnu": "db2bd4cc6389e2413fd91877bd5ff0d3b024b9e68fc402ad6b6422f61e6ab5a9",
         "x86_64-unknown-linux-gnu": "3927fd7a094ba063daaf3163fa1b3b0b196968356845fe31c901a23ecc5048d4",
+        "riscv64gc-unknown-linux-gnu": "f97f5e9d84528499c8fc31c3f295412f7ead44affd9c118c0caf54b4f7bd826b",
+        "thumbv7neon-unknown-linux-gnueabihf": "3e8f5dab01aab6acef3af4ee84e8d225a427c10fe84c91d8f188e57a5dd2413d",
+        "wasm32-unknown-unknown": "d79f31c54eab23c24e245e8988efa2f73451dc8537d386c52dcc1d7a6db246dc",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.60.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.60.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "4b1625ccaac350176c225861cb035438",
         "armv7-unknown-linux-musleabihf": "7e1d13f25ba9c878695c6a850113ab30",
         "i686-unknown-linux-gnu": "2976701fa2745b4c98ca45af39367296",
-        "mips-unknown-linux-gnu": "5a959084db2d4a3c38af1a904073e58f",
-        "mipsel-unknown-linux-gnu": "8fb9bfd98e4882055fda65a49a37edc0",
         "powerpc-unknown-linux-gnu": "0db8a8c7e3c2ff24572eeabd1547f947",
         "x86_64-unknown-linux-gnu": "688fabc8b9db1ae9a06ccdd4b200ff95",
+        "riscv64gc-unknown-linux-gnu": "7c5d265d562f8ce7c6b7879ff9cfa542",
+        "thumbv7neon-unknown-linux-gnueabihf": "9fbd7a6847757572fc3ba25c7bdc25cb",
+        "wasm32-unknown-unknown": "0c20fccb0b025b8961752735062e9ffd",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "90218ecee6c67a8d3d8bc94022d6e0a66e9addbe6a6bfcfa8fd4977ff743496f",
         "armv7-unknown-linux-musleabihf": "ba8da062d443e4d148feb080b1245fb2fc2170def8cb8cd71248b95b33c93a91",
         "i686-unknown-linux-gnu": "95657c1f612115bdb434f8a0e049df058ac2d3d139f347aa01007aca82951615",
-        "mips-unknown-linux-gnu": "baef6af894cb1f27b98d23fa9d6c63e13a2d8deb0a5fb600a3da69c565a8213b",
-        "mipsel-unknown-linux-gnu": "d86c1f4b7c6533f9e465f1962f77290c1d31c6236fe64fa5b8948e88aef63be2",
         "powerpc-unknown-linux-gnu": "a72afb10a6f360b50193d2e2919a7aa01733da0270379b814e346f1f5e3ab80c",
         "x86_64-unknown-linux-gnu": "963fd25a1f0e986a890e0f99f14902314c71e00f3b14bb587a08ca447ea7d1a6",
+        "riscv64gc-unknown-linux-gnu": "65bc755aa4d774e8a5bf301d2ae10a0544fc36887084485efc48426ce8f11740",
+        "thumbv7neon-unknown-linux-gnueabihf": "aed91f35af3d9bb886dbdf627889c2ac0edb2a39c9aa05dcbb7dd6a982a7af04",
+        "wasm32-unknown-unknown": "9f9472ec8a59ce2bdfa2616ca79113761ebeaacd03e5ef15edef5f075f643a4c",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.61.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.61.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "c483ffd85fd10a803a418bb3ac8d50a5",
         "armv7-unknown-linux-musleabihf": "e009067e0f170a937631075ba6a5e6ad",
         "i686-unknown-linux-gnu": "1ec00dad2e1ebbf91ccb9ab6e6f0bf7c",
-        "mips-unknown-linux-gnu": "0b4daa31872ed76c5fc30cfc198d0161",
-        "mipsel-unknown-linux-gnu": "f2e76b59c7bc2f3afa2f109ef126eee4",
         "powerpc-unknown-linux-gnu": "efdbd3e15bd966ac7e6aa0010050a1c2",
         "x86_64-unknown-linux-gnu": "8eb87473195fa7ba6f12e0d0300ac251",
+        "riscv64gc-unknown-linux-gnu": "b4092384e4dca24aa072e3bd7cdb5e08",
+        "thumbv7neon-unknown-linux-gnueabihf": "e9ac18203e0cb0e44b2de4865d6da28b",
+        "wasm32-unknown-unknown": "ebc659c18e99f6fd81729ac5c7c86ba0",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "34640c0064e15313c7d82a48175503bcb36ffc0e39c3384e899fe4bcde6c82e5",
         "armv7-unknown-linux-musleabihf": "3de3d5a2474e48df063096ef6c52f52e3ac718f15a3f1dd40f6accc3bb944e33",
         "i686-unknown-linux-gnu": "0a7687a9ce66e06ed92f82e2123fdad220bb3caa36a6764bcc8504187948b1d4",
-        "mips-unknown-linux-gnu": "922afca9d46a2a48aeec9f04171dd84f92fd1de13321023b3f3ffe0b9e1a3f42",
-        "mipsel-unknown-linux-gnu": "033417703a369959b957c09f8b3a99ef84bf6a204dc0efe622bcd3b099454f4b",
         "powerpc-unknown-linux-gnu": "763dda95a945a6effa6f8507d1f94fc690cda55612dc142406fb26f755a242d8",
         "x86_64-unknown-linux-gnu": "27383bf7b39d2ff1298fc0dfcd70ac70e1c01e70d7d0c60a2002c266a25b2015",
+        "riscv64gc-unknown-linux-gnu": "48e881544c256ce0fb2144a2d7cffef12ddd9421a1de1c4c48ec703f2e4482e6",
+        "thumbv7neon-unknown-linux-gnueabihf": "ab2d1c60c3ced5a9ece155e66215db4959ebe983b520ae011b36b14c42353069",
+        "wasm32-unknown-unknown": "c502b5894f226c2579ead0c45395327be63eadca75700979ef147a7135d55302",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.62.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.62.1.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "bf1d5575419429eae0427f9d68153842",
         "armv7-unknown-linux-musleabihf": "232b90e5498b4d58d89af7d8be75d3b4",
         "i686-unknown-linux-gnu": "d570b61de91491ede1c926adda42cef7",
-        "mips-unknown-linux-gnu": "8f6fa2b253c1d5c0836ebb086e88a609",
-        "mipsel-unknown-linux-gnu": "644664175ca40196f92af31e6b5c9abf",
         "powerpc-unknown-linux-gnu": "d725dccafdcf91eb702cc75730beb758",
         "x86_64-unknown-linux-gnu": "7e8c209615b1c65c4f710c2255010eac",
+        "riscv64gc-unknown-linux-gnu": "6a99842a5fe345d96992e9957f081e30",
+        "thumbv7neon-unknown-linux-gnueabihf": "a8afa00f62169cbf75130bc758632f11",
+        "wasm32-unknown-unknown": "08f6209016790f383f0c1d90c3c3d0a2",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "13515c3ef9356511bd2b750e98761ca08503f148db871fe08036d4a619b6d37f",
         "armv7-unknown-linux-musleabihf": "2a983f090160b3537faa18e3d852711ef757f30bd90eb53972a1f691efcd21c4",
         "i686-unknown-linux-gnu": "22c07df648225e1a1cf23ad84668772e2ea072174537353b739fd80464e74ab5",
-        "mips-unknown-linux-gnu": "0586a7c4b225a0ae5cce29229dbf4ae96a99d855830d6d436d32437530a6c7a0",
-        "mipsel-unknown-linux-gnu": "2aee14fcc2e393eaee744c4ac158d2b9ad159f9982124b2cd4d5ebda23f1417d",
         "powerpc-unknown-linux-gnu": "d409da640e9b46893d9d07fd493a1cddd622f399e945e2da9ce127ddf9f82b7f",
         "x86_64-unknown-linux-gnu": "564e5afc7151826190f8b31ed839fc305469158967ffe907d4c6e712a281ff5f",
+        "riscv64gc-unknown-linux-gnu": "00dc6aeca224a98437e87e893fb1c94263ad3971daa78f731d43f7835bf31283",
+        "thumbv7neon-unknown-linux-gnueabihf": "c24c32d21a9babfb3da3649ecf2374d6f0b344c56a0b1cc10277124593ea4a30",
+        "wasm32-unknown-unknown": "2720a4d88a4940c9c73be36f20c95c87ffd79ae1a47c5e8519a6a95e7a1f0750",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.63.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.63.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "dc85de93030ce16c2ccfe602ee778164",
         "armv7-unknown-linux-musleabihf": "773bd7a1c5a294fee0aeab5b2232c7bf",
         "i686-unknown-linux-gnu": "748087a92606e191266500e87060baf4",
-        "mips-unknown-linux-gnu": "f98a0ba89adddf0471bc6e8153c8888d",
-        "mipsel-unknown-linux-gnu": "5c1083e09f134cddb29937dabb2d5665",
         "powerpc-unknown-linux-gnu": "f6b8de0e7584aafc05592558c14dc920",
         "x86_64-unknown-linux-gnu": "260c066bc19d6963296033d66a8b42cd",
+        "riscv64gc-unknown-linux-gnu": "3562d75a0f82d0aa414bbb4a24b3d8e3",
+        "thumbv7neon-unknown-linux-gnueabihf": "0ce02d857e15f1383a47ba9ea9ca9535",
+        "wasm32-unknown-unknown": "1caff4ba2026f4ecd01acf209d85e7c6",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "998c9a1af2fce446f37b77d6400a32fb3097def293d2f73faedd0d0cafd42a33",
         "armv7-unknown-linux-musleabihf": "d37ae049dca59b174db5b54a1c157b54c8cc49396699e135f5fad9d306568ac9",
         "i686-unknown-linux-gnu": "5df51e9119d49addbf78ca6fbaf78a869f7aea46853a8fdfe339d543d0d88c3b",
-        "mips-unknown-linux-gnu": "0e235151b2f33a03a4717b2e9f3644a3d3ef502844545fea3645214403ac143a",
-        "mipsel-unknown-linux-gnu": "696c84c83cb22c3019ff18cdc21fc5206bc7e56d4f51c86e26dc4ebfaf952aa5",
         "powerpc-unknown-linux-gnu": "460dbad0c90b35c3adda748d62efb568c8bb7703c8ce489a4da05c75c594a841",
         "x86_64-unknown-linux-gnu": "4211c28e3359e915c116524aeb13a728dfd1e8889d1b01d32ed64b2995534eae",
+        "riscv64gc-unknown-linux-gnu": "81c86715aaaf53f9f12b63a6f1e88f4fe933e05d9f3b29c8616fb077f12a9a18",
+        "thumbv7neon-unknown-linux-gnueabihf": "212fba32e5dbb630250666bc8bbd26fd41f6b4baeae38e7594955ffb66684a55",
+        "wasm32-unknown-unknown": "0ba89f8bd8a563c4af34060d0261cb6ffbd11cca1277797510ebfece91ec7cb5",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.64.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.64.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "a6239db0d95c7fc89aa99e6aa00b65ca",
         "armv7-unknown-linux-musleabihf": "54356eaf637527c0d1fcb5580c3a412d",
         "i686-unknown-linux-gnu": "ba473109bde4c7ca5491f8f8db692014",
-        "mips-unknown-linux-gnu": "7155648af1938642e3ba87c1bc1125c9",
-        "mipsel-unknown-linux-gnu": "81f6e3359d8a481aea14f6f41bfc7014",
         "powerpc-unknown-linux-gnu": "59deca4b85e6a391486de00ed33f9077",
         "x86_64-unknown-linux-gnu": "de4f3c1cb2f1949eefb4cb6d4752875c",
+        "riscv64gc-unknown-linux-gnu": "d860f3c14e2d440cf2711752fd76e832",
+        "thumbv7neon-unknown-linux-gnueabihf": "91a7b3486ce6bd2fe5a058d44c3d73aa",
+        "wasm32-unknown-unknown": "69110b38c462bfce7bdc3ccc6dc32db4",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "9cda1ef1d14372d7c5288cc69c9b5e9f211f5bebf7da22fae6d6ca8fc06ed687",
         "armv7-unknown-linux-musleabihf": "bb233eb7c5dd2f8ae50c4874aea1a8b2e9965f92d184c4e6574f6db45f3c0562",
         "i686-unknown-linux-gnu": "50b32b772e2eb993dea89011fd800c291889c05ce615e45d9a260ee568661069",
-        "mips-unknown-linux-gnu": "1649e72798f14336c25019cf0d5e800016f9087e9e703749c456e1293178f01d",
-        "mipsel-unknown-linux-gnu": "6f0e5498ab6505e3f4312249fc369eded48b9d4f33f910eee438936ad5d25758",
         "powerpc-unknown-linux-gnu": "61d228cb732ddb85802465781b69ed20719314adde5863805cdcac9c3cc1336f",
         "x86_64-unknown-linux-gnu": "4d4c2715f816bc8ae82c2a5904106fd4dfd668dbd9a98492c8cd388bff9b0b5c",
+        "riscv64gc-unknown-linux-gnu": "5b8e8e67ae67ac74699b976043615f029f487c4148fdca4cb33fe7fe90192860",
+        "thumbv7neon-unknown-linux-gnueabihf": "320efa58b6066e0b640b9b93330f89f27a14cce490d8a5eafe33f1d3949de5f1",
+        "wasm32-unknown-unknown": "1ecd99d7c8d568156957fcccb2d064eb8e1be3c309e216ce74c65ea549994d73",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.65.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.65.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "23366d28280630ed5f1e6e58ad814b19",
         "armv7-unknown-linux-musleabihf": "849e4ee23eb914c7dd4a9472c2b92154",
         "i686-unknown-linux-gnu": "e59f1b78805719352413a73e725a7c00",
-        "mips-unknown-linux-gnu": "a996611552e9226e44928d69c9407eb2",
-        "mipsel-unknown-linux-gnu": "9dcbcd8e7638e5b7d84665195ca45b82",
         "powerpc-unknown-linux-gnu": "b76aba28748a5c4534116a9d1002d3db",
         "x86_64-unknown-linux-gnu": "ea4af6c5eab4e990449b1bd1e6b432ce",
+        "riscv64gc-unknown-linux-gnu": "38011531406f956175f2e4615bd7bf00",
+        "thumbv7neon-unknown-linux-gnueabihf": "47540b5d4fa7aefbd9d990ab2874d4c5",
+        "wasm32-unknown-unknown": "054992d043e3f66b4c0b00971672f32c",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "616714d28c5c4c0273a22cbc18179ba5354d2e3f4dfc300024266c46b4f68127",
         "armv7-unknown-linux-musleabihf": "da790276100bf066127987bb7964325379ef249f887d17fd3e26bc1628700a8f",
         "i686-unknown-linux-gnu": "8f3c90a21494b90e7f7bb16ee8f0b170b4d63389b05ce6c158eeedf5904d51fb",
-        "mips-unknown-linux-gnu": "83cd534c97c44b3cda6eb2b5bc1259906cd7b7c4711950d62816736eca82eff3",
-        "mipsel-unknown-linux-gnu": "646398fdd4ee9f5b9a96aee16c615a4f32f77f2bcdc7ee2a4f5f2274cf1d6b92",
         "powerpc-unknown-linux-gnu": "7c1f66581e7024e6e3ecd69db878defd5ea4a88b8b049ffaf62965ce9d652b15",
         "x86_64-unknown-linux-gnu": "8c194b0e3814efecb87fc4779767ef17d25399fbd476dbfc92f9a7f88b98f784",
+        "riscv64gc-unknown-linux-gnu": "ee47cf94cd4fd130a233518236f49b742f7f29bb66e2256be23ba71a292430e2",
+        "thumbv7neon-unknown-linux-gnueabihf": "1102d8d4f3cea919ffa97655120f312dc4ec52c86918966f87c0145a055b4a5a",
+        "wasm32-unknown-unknown": "177a35ce65f969127bbd58ef08e24471afb2c638a811104c493699a23f5e0006",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.66.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.66.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "683a4d5967e382cdc07d27d56228c9ed",
         "armv7-unknown-linux-musleabihf": "4b5e67936bdaa7ed0fd159b693ed1007",
         "i686-unknown-linux-gnu": "0d2d21d2bfb222a4722aae6ef5147db6",
-        "mips-unknown-linux-gnu": "9f1cbbd81f364fb0cbffb242694ccee1",
-        "mipsel-unknown-linux-gnu": "1b97dffc9efe719774aa9c52552b8b03",
         "powerpc-unknown-linux-gnu": "baf39f7a39b65bca835445f81ccc3db2",
         "x86_64-unknown-linux-gnu": "e1df18014d62b5281fee762c8a3afce1",
+        "riscv64gc-unknown-linux-gnu": "0404e5c555e609b76162d97c1b729b4c",
+        "thumbv7neon-unknown-linux-gnueabihf": "adb6807b6248045ed39e8c28affe4fa2",
+        "wasm32-unknown-unknown": "e48d071c18d1caea99574d6e9f8b6da9",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "c88d163b38317d2e3d92925cbd5986a89a1f67b764435d805df84052705e0aad",
         "armv7-unknown-linux-musleabihf": "06518d7fe1439352785147f0553e6e99f83b3366aab566cb9112381008157798",
         "i686-unknown-linux-gnu": "4276bbe18b7570ba3069485faeee4930d52a795965443f073707ea8cc40c99c3",
-        "mips-unknown-linux-gnu": "26c31d3cbd2797c7175d54ccf3bffa76e169683ac25e884f2866a6c261476198",
-        "mipsel-unknown-linux-gnu": "84afdb4c88112d06b88743e24ab86475296ffa8e9f56180c9572c5eb679e6478",
         "powerpc-unknown-linux-gnu": "033305c6a9f543ee702060114577ecd5a7ba7316f2a7f48797f1296baace36b2",
         "x86_64-unknown-linux-gnu": "0449a5219eaf05c53a141ee664afcb46c75c78b6500d0b082b544baa72a78cbb",
+        "riscv64gc-unknown-linux-gnu": "3b945928f8bd7542048ba3c8509a50c428e256779766e8dcbe4382426dd54a0d",
+        "thumbv7neon-unknown-linux-gnueabihf": "458e8b12c7ccfeeebe978c8009a910b1117dffec434f2f37daab9ca25cc2222f",
+        "wasm32-unknown-unknown": "df2c1a042ca4246181af9182d51d6c2921c2e5cbc536a160352ed019079c5474",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.66.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.66.1.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "05e483655f6cc825bab204269d5075a7",
         "armv7-unknown-linux-musleabihf": "a5b41b026fd23cc1cdfcbc554b69e7dc",
         "i686-unknown-linux-gnu": "f2c6072cdec5d2dae68ba82569b0b8c8",
-        "mips-unknown-linux-gnu": "4e8fdcc2c37b343657217e35bcfe61bc",
-        "mipsel-unknown-linux-gnu": "889e10d7127359c96d6f1d9e67c0f26f",
         "powerpc-unknown-linux-gnu": "f7f761f8bd91684ab447aeedc2417332",
         "x86_64-unknown-linux-gnu": "4e1545cd02387cc624e06e405631b850",
+        "riscv64gc-unknown-linux-gnu": "c27c89e88b19378c6dce1647d1c8e531",
+        "thumbv7neon-unknown-linux-gnueabihf": "11b886b091f43de2e3fd6a8dfef4c267",
+        "wasm32-unknown-unknown": "8e74bdccd17aa5c2ec40bcf75b7bb5c2",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "c4150af5f8366cb4a9e1fe4bd982ee84bb66789c3b5085c55f6f7ba8012a8feb",
         "armv7-unknown-linux-musleabihf": "bd43b68a4384acd7a5b862e2260c3a1eff8897e4e7fca1a7032d20e8e7c1c701",
         "i686-unknown-linux-gnu": "e8a937cb56aa2f644a537f403b4e92978cdb17a2e4d8b737f4a9743bb17724b4",
-        "mips-unknown-linux-gnu": "d61188ea93c117fb7534bd49c46f2f0116bc880f8e49a591688cbc2d4eb594d6",
-        "mipsel-unknown-linux-gnu": "cdc9a4caa8356e49c7f5d0806bf8f8cef693eb03e42d875388abc0bbed9b8099",
         "powerpc-unknown-linux-gnu": "c70872a80ca38b2daa83132da5ea979e443c8d973d4692fbaee8b9134926c8c1",
         "x86_64-unknown-linux-gnu": "b225606cd0cf02b1f5fc77420647a28b35f22d67e565dcdbe29f0c919245565f",
+        "riscv64gc-unknown-linux-gnu": "48ecc5b05c297f93af106be6ccf04cae5d478e5e53cddfd34ec19b860a591948",
+        "thumbv7neon-unknown-linux-gnueabihf": "45ecf852dd4c0969434eea9f8b1680a7d0af0e3ca80dc134c2c87577dc6b99d9",
+        "wasm32-unknown-unknown": "c1fcba65c7521fd4affb8a56df4d8435d0cbc8d9e2fc19a07a41daa05517d385",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.67.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.67.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "9d37aab7c50b122d6ef16c791c95940e",
         "armv7-unknown-linux-musleabihf": "b97c2f5636971b886913ea3972e57f68",
         "i686-unknown-linux-gnu": "db3765fc976f13c11dd311c455737189",
-        "mips-unknown-linux-gnu": "0ef39bf1882411ee226fb4e13fd22cb7",
-        "mipsel-unknown-linux-gnu": "4feea2392240121a5b8eaedb02edae86",
         "powerpc-unknown-linux-gnu": "9931a9713c94f8ab837e6b2b867f5e4b",
         "x86_64-unknown-linux-gnu": "8bf77dfb3e418bbd83cf03aa2a29a581",
+        "riscv64gc-unknown-linux-gnu": "827083f342c16075a326b89125dcb4db",
+        "thumbv7neon-unknown-linux-gnueabihf": "d7c2923918abcbc39fee3b25b389e510",
+        "wasm32-unknown-unknown": "33e8d6840e1db3276f6c4fb50a4a5ba9",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "0ac50c8ea22308044125c0956ab916d16160b5b0cd01b7479c868e65320467e1",
         "armv7-unknown-linux-musleabihf": "6d8a092005fb8ea480a84346bde55047e8b0e23b78f37e38b482aad9e4649fea",
         "i686-unknown-linux-gnu": "71e0ce5ae10f4b48fe8b45fcc0b7f2e70bad29f1095f4251c838cf070465beb1",
-        "mips-unknown-linux-gnu": "25408c8cbdd8bd6fda789e71c4774692480c16cf0d40f416954116fad569bd3f",
-        "mipsel-unknown-linux-gnu": "6c4522b65c20e5cc968f7e3b9b79506051c2026ad1264435705344a6c6d7f472",
         "powerpc-unknown-linux-gnu": "379c4f43c5ad7a5237a44bc1618ef264005957974417580cc32150ed30ef718b",
         "x86_64-unknown-linux-gnu": "eb334a2e07da87c749010844a70d815efddfe6f2572faafadbf126458a2724ca",
+        "riscv64gc-unknown-linux-gnu": "0ee76277930223423c1aa4539b0422012c1ad1f026434487dc2761f25ac2b8fb",
+        "thumbv7neon-unknown-linux-gnueabihf": "71383427e84b7be24e6ac79ecce5f6f77542c26d20dc4dcb0417479e8352b9bd",
+        "wasm32-unknown-unknown": "9bc09c4a9e09975a92be540039051d5cf4445e66f129c643a40e86f21a42a3db",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.67.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.67.1.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "594d5b87a42caab5db2d6c1f083c922f",
         "armv7-unknown-linux-musleabihf": "bb6013f4fabd0696f56d36345c5bf50e",
         "i686-unknown-linux-gnu": "3727ee658a79622ca7b8a30c60f7cd79",
-        "mips-unknown-linux-gnu": "aab8a4259925f3cbe3e8adf8cac08678",
-        "mipsel-unknown-linux-gnu": "9971cd62223276aacb2ae186b38471ea",
         "powerpc-unknown-linux-gnu": "c1b7f02188225c8b2ad2a15326c1300f",
         "x86_64-unknown-linux-gnu": "453d6a64eaf9b7e2a67a84911949fc03",
+        "riscv64gc-unknown-linux-gnu": "ae3787f1797102831632dff1b509f996",
+        "thumbv7neon-unknown-linux-gnueabihf": "6627d17243ee275c5255be984810ef29",
+        "wasm32-unknown-unknown": "1651fc3c6c44ea84abf1348672e24c13",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "711aba76f98f630b6b51ff4e72ad350382e325bf8c06a7f6a949f12c44dbe5ff",
         "armv7-unknown-linux-musleabihf": "420e1fbb2309b3083c892279b74d41f95462067a92b3e059e0cef0829b6edc6b",
         "i686-unknown-linux-gnu": "af9dabb8126b7dfaa00eefc2a04b304685109b33929c54b6f4ec0e523776a8ce",
-        "mips-unknown-linux-gnu": "40fb4fca0af8fc3452fcd589e0c1b265f53816bc5e742a8033ca6545a5a69dab",
-        "mipsel-unknown-linux-gnu": "940132da5f30f86a4cd87b1c9c37b4f9a6e0cebaaf5d74d187be72383f571a13",
         "powerpc-unknown-linux-gnu": "61d376eca89cf0a1b103824862651f7ad5abd7d4bc0f604f8f2fbb261cea8a85",
         "x86_64-unknown-linux-gnu": "31dfc19ae5821c0542975111574aa8cc7e0b2e1a95204f6cff7572f183524626",
+        "riscv64gc-unknown-linux-gnu": "2eb7150a54d0efba20ad98def3b96a4cc7c9e7de88f72e1990a249e6241ee74d",
+        "thumbv7neon-unknown-linux-gnueabihf": "d16d0fc9073a8af4da2bd621d1ccd9d50c293a958baa4ec8fb1821a6e6ecf1a2",
+        "wasm32-unknown-unknown": "2c112ddefbc5df8d2bd46b05ed3046169ed6a5ae081ba84cba2e0bd21ba70317",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.68.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.68.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "1d73e9dbb93a17eff8daed594f3c1b4b",
         "armv7-unknown-linux-musleabihf": "79f20ed1ad2eb10f76d6d445af02b2ad",
         "i686-unknown-linux-gnu": "3240c05b0f63ac85b0e8891c38fde126",
-        "mips-unknown-linux-gnu": "2c44533173cd2c6602a6f46dabb8ce13",
-        "mipsel-unknown-linux-gnu": "cf2d3686a4e206abcf485d665465bf5a",
         "powerpc-unknown-linux-gnu": "faa9be4d555d4ae20054f67b81868209",
         "x86_64-unknown-linux-gnu": "46c9c8247bd7096baefb195d01258176",
+        "riscv64gc-unknown-linux-gnu": "94f993b8bc6823cdbd60afef8ac8fd59",
+        "thumbv7neon-unknown-linux-gnueabihf": "d66fc1dc3875d99290187ea8cd0ce747",
+        "wasm32-unknown-unknown": "5389553d5f02b7cc20a81661d413e9f1",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "e919a141af4aef500059a80cd7746aadb80dff88676e6919a0ee4f74c2272569",
         "armv7-unknown-linux-musleabihf": "52975246828ecd59164aa5b623c4dbc1e466712bb4ae3015e0a463e1214755a2",
         "i686-unknown-linux-gnu": "d9d4572a5cfd668ecbc219a42786ac2d6aa18708447c987965ef2d1c2ada661c",
-        "mips-unknown-linux-gnu": "dd76eec4760f056532d5719621dc83c0d83a76970ce850cdecd9a7aa1a65902e",
-        "mipsel-unknown-linux-gnu": "7afdbde48352f41229f5819e3f3fc5e09711688f91a482002295e7da011517a9",
         "powerpc-unknown-linux-gnu": "23d2fcedad4102d884cb35774a6ca8d765e0e07825dae64dbda19112ad99d6e9",
         "x86_64-unknown-linux-gnu": "67b8cb1610b254c296107e2516083897aed2996bb7618561520e0a1f0923c696",
+        "riscv64gc-unknown-linux-gnu": "f5f9eaa9a4661e3543f284f4b0f54174991abd7078b3de9252fd59a9819d7a50",
+        "thumbv7neon-unknown-linux-gnueabihf": "2942c9fb72956c77b7738f346e2ad2c4fef044c78048f05964b09d01cc189712",
+        "wasm32-unknown-unknown": "7fa9c48e3cb2bb5d41cd6a6145544d37713beb84f32c7ee55f27d9a655918064",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.69.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.69.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "1ae62f90f18889e99f88e9be75787bce",
         "armv7-unknown-linux-musleabihf": "0a9f391525a0ce6632236400f6539fca",
         "i686-unknown-linux-gnu": "109e0e1abcbeff7d44fed74c72802a59",
-        "mips-unknown-linux-gnu": "3ff8ccc3cef790995433c8542414e107",
-        "mipsel-unknown-linux-gnu": "285ca44b6cae1af4ea660178c9719035",
         "powerpc-unknown-linux-gnu": "4a8ded79e923eb9afc4c5d750609c322",
         "x86_64-unknown-linux-gnu": "d9a9bba8e16426b641f2f8113d9c4104",
+        "riscv64gc-unknown-linux-gnu": "a546d5640a5629f0bd73b93635a2d592",
+        "thumbv7neon-unknown-linux-gnueabihf": "251f8a4e47391574eec8594f40d7c657",
+        "wasm32-unknown-unknown": "b681adfaac8d9309aa8a550a7b5482fa",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "08edc4547495299393a0e18f8eff740d7cf31e00ad2b31671688e5e4438abe16",
         "armv7-unknown-linux-musleabihf": "fadb41835ada212a248f663caa0c727e32a3c8d9471bea25f63a948b760e3124",
         "i686-unknown-linux-gnu": "d54849ab7168e16210107b812871bea7f282a3f50b4b34aa252f04f25f8a8bf9",
-        "mips-unknown-linux-gnu": "032e5b35b2883a9a5fc29e191c1103be8ea33af90b35d26305da5bdb847dd65d",
-        "mipsel-unknown-linux-gnu": "3101831757ce93c10b4c394e1f979176e8d1ca72492247d2a043f4a9fcceb24c",
         "powerpc-unknown-linux-gnu": "dd5c877591ad9df7a5cb541e23be18d1ca7ccc04850c20118b1eab35625845b0",
         "x86_64-unknown-linux-gnu": "b6986b4042af7b17fc8f51127018617b32d45cd555c582efa816ac194d4b53df",
+        "riscv64gc-unknown-linux-gnu": "b8b03db1ca7286976099fae83b972b320aa69ea50b94c8a1a4001e9a3b85c888",
+        "thumbv7neon-unknown-linux-gnueabihf": "6d9765056f095182a39e67f51fea587f445096307c77a46421c8eaeb8aec4ac4",
+        "wasm32-unknown-unknown": "895f79222ea5d9cc50a1257a8ac208c1525ccaf8f25dcc138183a6cd61be79d6",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.70.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.70.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "69d5570003311cd9b3f9493d2da9d311",
         "armv7-unknown-linux-musleabihf": "dce04c579aa064f9ebf943863ea0a7b3",
         "i686-unknown-linux-gnu": "32095a189ab66b0d8fbfd3d20a7907f3",
-        "mips-unknown-linux-gnu": "f375cd20c5d1334521a279983c1cb235",
-        "mipsel-unknown-linux-gnu": "7e18d1d9cef2f7d72b61f9ddf429e918",
         "powerpc-unknown-linux-gnu": "1661a71982ffbf30f0127e85f02665cb",
         "x86_64-unknown-linux-gnu": "f94d293a8a3f8fbdedf5220c3f2676a9",
+        "riscv64gc-unknown-linux-gnu": "5461e81a31f21ea5d408cbeb5829fb08",
+        "thumbv7neon-unknown-linux-gnueabihf": "ff5bccee638ffa130ec7edb1c5ef0ef9",
+        "wasm32-unknown-unknown": "b6410256c41acc9dcfc303c34435396e",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "3e3687fa87ce6549cc1f508d4888508531d70482fce210c19dad24b29b8e4e1e",
         "armv7-unknown-linux-musleabihf": "57d075caeac0ffdaa0c47accf7fdf6458f5b73fbd8cbe3c42937d348d422f056",
         "i686-unknown-linux-gnu": "6cf40f9cd6efcf225fbd3a1da62fc589c4b946c6c3e25ab4fadaa4c948e10016",
-        "mips-unknown-linux-gnu": "c1bc7f7b963da3288bf5fa624c0e0511d1da8983bbf5cac6c3e305688a83d3cf",
-        "mipsel-unknown-linux-gnu": "248bf2b1e24d712cc20675d62ae5bc5564f1ac5825790cd95e2fa203da46b85d",
         "powerpc-unknown-linux-gnu": "27c10ad6ec6fea23980a5b28d51bcdf9e4b7206636e1570bc994c0581f950907",
         "x86_64-unknown-linux-gnu": "d921afdcf5218bfe144b74bd16b4c18d824bb6194e6ff92451f0ed749ca025f3",
+        "riscv64gc-unknown-linux-gnu": "3a275431d0dca26d577f4acb54d797dc6b61f2d0b74d472efe3d0cf3b808e716",
+        "thumbv7neon-unknown-linux-gnueabihf": "edd19412e3704ae1688c6ac5af7ad948d6802711e9a04d52c0cc39379f40d230",
+        "wasm32-unknown-unknown": "3e35a53e22810fd6beb2fd874cc9898724b473f85ffcfdf4a45aee1bd01da78c",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.71.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.71.0.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "984aba1b6e77ca492660cf6a02bf5aab",
         "armv7-unknown-linux-musleabihf": "ff84febd5ec992238d287986e05b245f",
         "i686-unknown-linux-gnu": "d416abbc3c033c11212e14a5a4e4a045",
-        "mips-unknown-linux-gnu": "616212dad6e0cf525993da80fd94e8e5",
-        "mipsel-unknown-linux-gnu": "d92fb23a44403dcdeb94abf76de83047",
         "powerpc-unknown-linux-gnu": "4bead8ac368c0f338ddbc4c5fe67f762",
         "x86_64-unknown-linux-gnu": "4480c75763f0ff90f919fb2c33d63e8f",
+        "riscv64gc-unknown-linux-gnu": "e3aff819eb6b503db4a46116c3d6322c",
+        "thumbv7neon-unknown-linux-gnueabihf": "743a4c3c9c24adfa632e60aca289901f",
+        "wasm32-unknown-unknown": "7b55396f911b1d64794b5bf66539572d",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "e0340bd594dcce9cfa9aced2cdc97f3acb130c2018b9e6039838daca32ef708a",
         "armv7-unknown-linux-musleabihf": "7ebed3fc640c21ae33110a453d8e6313a81c5be0e5e30ab368c4bd5accd11ccc",
         "i686-unknown-linux-gnu": "a870d3aea3723087da96b13d48e3725f50c67aec12567eaaf48d5e322a328d3f",
-        "mips-unknown-linux-gnu": "9e8be732cac819f2ca04ee90f520f0634d61e9bf93b9215252ca1142b36da8c4",
-        "mipsel-unknown-linux-gnu": "8ac6e6435e7c1f229cb70008498dccdcc5445d3a936a4bcd650902e7e7708b35",
         "powerpc-unknown-linux-gnu": "a46f5b669f4f8e456083f2a2ffba0dc90a4e1825f545ac1a10c477ce5ae64396",
         "x86_64-unknown-linux-gnu": "2d7ae16a5baa4df96a142547e7954f539190aeebe90ee524642bac51fdb32156",
+        "riscv64gc-unknown-linux-gnu": "c9af3d9ad23f2b5fcf56b7c74402fa00bb65e2d893b40fe110c11cceb9c84998",
+        "thumbv7neon-unknown-linux-gnueabihf": "191cd2641c8416e326cffba280f978172ae2c2da62ceb6b9eb215019bd1addf6",
+        "wasm32-unknown-unknown": "c66bb9b7ed602694f8ab62e845da164616bd8100d7f529c86dd47a837927f005",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.71.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.71.1.bb
@@ -17,10 +17,11 @@ def rust_std_md5(triple):
         "armv7-unknown-linux-gnueabihf": "5dc306d424327c09a95ffb6d49239514",
         "armv7-unknown-linux-musleabihf": "55b187e789829bff81eea24de6076e10",
         "i686-unknown-linux-gnu": "067e33e7d9f54fc3736c51f98fb42969",
-        "mips-unknown-linux-gnu": "bdb2339c981e1122ebb35dd6f6737014",
-        "mipsel-unknown-linux-gnu": "43b525a9e26870ac8129ac3a4ea99c27",
         "powerpc-unknown-linux-gnu": "d57ff6baae4cc62ef99e5ed35c5efc1d",
         "x86_64-unknown-linux-gnu": "66cdd65c8cedf15b3782334c304dbc4e",
+        "riscv64gc-unknown-linux-gnu": "6697fe729e2312a23367ed272b01962d",
+        "thumbv7neon-unknown-linux-gnueabihf": "c371d77d27eda44dc606c9d5e86a9c7b",
+        "wasm32-unknown-unknown": "5876373ab71a5987ae12e7141b6d37f4",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,10 +36,11 @@ def rust_std_sha256(triple):
         "armv7-unknown-linux-gnueabihf": "6b5df36c1d28f64208de66384547bd3489a1bc1041ea17901530a758e558dd14",
         "armv7-unknown-linux-musleabihf": "545cf1613d8ad4efd0d6c7cde21c2d15d1c8eca3e464d9f14db01323bb0220b5",
         "i686-unknown-linux-gnu": "a5d4dc0317406c587e027f2586b77c5841fab5226716f51a441ac63a0acf3d0e",
-        "mips-unknown-linux-gnu": "ca6ec963222492215c3e490ef6d6d719074ed81e6a516b889c13b3fa5e6dceb5",
-        "mipsel-unknown-linux-gnu": "880d1cdc6d7360ea0adf45b37a7ca88a31175ebf5d819b7cd26606edd42250c2",
         "powerpc-unknown-linux-gnu": "e5d4668148c6a72bc64daeff089c1c258371b4ea2ee5e3691c84f202f70a7a98",
         "x86_64-unknown-linux-gnu": "2bbcfba62ad2d2cf05c53d91c578e5cce766d5308cd49a1e425139470282865e",
+        "riscv64gc-unknown-linux-gnu": "f416fa24f2c62aabb381718057ab82cb538f3e7dd4cacf52dca3d5114ea3d16e",
+        "thumbv7neon-unknown-linux-gnueabihf": "1f7b812d908fe6d074626a5fb2a739254c8a50698469b87377f9760cc461d990",
+        "wasm32-unknown-unknown": "2d1ee290dc13a5b33ed754b246eba57f4b284ad16966063094ce26e9d435b965",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.72.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.72.0.bb
@@ -19,6 +19,9 @@ def rust_std_md5(triple):
         "i686-unknown-linux-gnu": "aca6c601c083599e8b120c913a78dd7e",
         "powerpc-unknown-linux-gnu": "ffeb18c944d8789d627f7054fde5118e",
         "x86_64-unknown-linux-gnu": "336857bf48bc1fab0073893b272b56a3",
+        "riscv64gc-unknown-linux-gnu": "feb23cbab135b30a411944ddec5ae6d2",
+        "thumbv7neon-unknown-linux-gnueabihf": "d7877a322705343676a3a1d325ddbaa8",
+        "wasm32-unknown-unknown": "490dcc269015cce42b7c570f1dbdb71a",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,6 +38,9 @@ def rust_std_sha256(triple):
         "i686-unknown-linux-gnu": "75708e4e4d01a3106f6d84be1a70b22405f57cc04ae1390c3604e74fe957011e",
         "powerpc-unknown-linux-gnu": "8db8bda10b87e6717ac90e78cc5ccdcb8f5c3d8c6a3b9cd5016df836784dd6e0",
         "x86_64-unknown-linux-gnu": "89f6f6ef25e7e754940c54cc0584bfdb83e1df75019d5aa126e3fa66c2921b15",
+        "riscv64gc-unknown-linux-gnu": "147acdca12fb094dc7db0adcebeda665c3bf8e76a185f8c74decd9d68075950d",
+        "thumbv7neon-unknown-linux-gnueabihf": "87c08894b59f07961adaf88273f0684b32cd30cfd730e44cb114fde640468cdc",
+        "wasm32-unknown-unknown": "5ba9b055ab928f952001628d60df020e81c975119717f4823344e50c04280a6f",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.72.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.72.1.bb
@@ -19,6 +19,9 @@ def rust_std_md5(triple):
         "i686-unknown-linux-gnu": "8e00b1171a851ffc5d4cf534ba40d647",
         "powerpc-unknown-linux-gnu": "f0db96c1546ff0f07d02cc98d0b2c2fe",
         "x86_64-unknown-linux-gnu": "bb20a9de56624b1cfb74b6559427f6ee",
+        "riscv64gc-unknown-linux-gnu": "43cf491b7c656d4d673f6524b8013762",
+        "thumbv7neon-unknown-linux-gnueabihf": "cd626420cf6de6da0fc554c41447c346",
+        "wasm32-unknown-unknown": "b963cb8a6e980ba5572d25a638113aa1",
     }
     return get_by_triple(HASHES, triple)
 
@@ -35,6 +38,9 @@ def rust_std_sha256(triple):
         "i686-unknown-linux-gnu": "e53a82e2dbd9af74c3e91583ce8fe5911907f7f86f57f7e15c1f633a0dc44c1b",
         "powerpc-unknown-linux-gnu": "0c727140589d214dd7a1616776f1ab9718025065e61c32f199f62d91b68e8419",
         "x86_64-unknown-linux-gnu": "d5d3751b4558864fd95f17b1b6eaeff3130a3de1a6920750a3b8c6b0fa03fb1c",
+        "riscv64gc-unknown-linux-gnu": "543b9ff59bdb0c77a35e14d7373fd939e7aeceb3df428f3bada23de6becd896b",
+        "thumbv7neon-unknown-linux-gnueabihf": "839e36f56e502fb762634a3903f2554fa5a226a98a5a654f9d9137f5d86d3ca8",
+        "wasm32-unknown-unknown": "32e49d571a36dfd1440f48d97c5451780b5b12186ff6b60293f1a06231132932",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.73.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.73.0.bb
@@ -20,6 +20,8 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "28a5c267b8606a31e0d3a23306e38118",
         "x86_64-unknown-linux-gnu": "b687e1e8c08d4cf88065d271a75dc633",
         "riscv64gc-unknown-linux-gnu": "f435089285829aa133bc46214c629047",
+        "thumbv7neon-unknown-linux-gnueabihf": "5b8b5dbf2eea4b06542f942bd001c0af",
+        "wasm32-unknown-unknown": "e2dfe44d0512d6a98e99cd8ba36c5f04",
     }
     return get_by_triple(HASHES, triple)
 
@@ -37,6 +39,8 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "49692419b05e82adf1099ebc17468f9bc3d411f5d42d39ec77c13473f2b5ea2c",
         "x86_64-unknown-linux-gnu": "9e941972c8679c2d852addf979455afd61e3ec33000cbc2421b162bcb05897a6",
         "riscv64gc-unknown-linux-gnu": "18438669633be274ac50011bd4c8b9ae2d94174c9eb5a219569ad9add7429e23",
+        "thumbv7neon-unknown-linux-gnueabihf": "12a862561090e64606bcdb0fee285a4316b6fffc7f231b36f700e69e8e99a3fb",
+        "wasm32-unknown-unknown": "f5b840b93f00db0785c32f5193b6e3492fe4c626e148a5ebffe07184b6435104",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.74.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.74.0.bb
@@ -20,6 +20,8 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "3604a48ac4495d6053c56303cffbb54e",
         "x86_64-unknown-linux-gnu": "4895aa6fdd0e5e1e705374ba919b0934",
         "riscv64gc-unknown-linux-gnu": "a27729fd04b97ac4535580ad188894f8",
+        "thumbv7neon-unknown-linux-gnueabihf": "4988f01bbeab4e0a59e892c7dbcb0932",
+        "wasm32-unknown-unknown": "4960c45018c0ac54b1767df6b044864f",
     }
     return get_by_triple(HASHES, triple)
 
@@ -37,6 +39,8 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "d8a9322fb6c1be2ac52bffff089cbeb72b7da5d4d7d274c8935fc8de520db7b3",
         "x86_64-unknown-linux-gnu": "798b3243d9236e4dc5d43f6b186333cd30c04926b2229568d1fc0f0eb432507f",
         "riscv64gc-unknown-linux-gnu": "67f23b2fd2981e9d83d26506a2222b7a6ea5f89d42786ad6fcabdde89c46c546",
+        "thumbv7neon-unknown-linux-gnueabihf": "91617edb6ba928be3a3c58b0a039339ec7cafc6883ab76d8329b92fb740c2eb2",
+        "wasm32-unknown-unknown": "638e818db424fcc66bacb24972da089af78a0ba75d77557b2869d8ef886cd8e1",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.74.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.74.1.bb
@@ -20,6 +20,8 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "a1299b530bfd3c0473d7206c951a30a2",
         "x86_64-unknown-linux-gnu": "0daacc6f2d5362ab8ead7ef352e7dc3d",
         "riscv64gc-unknown-linux-gnu": "2e6a29cb27029d4c1de70e40f6813fa1",
+        "thumbv7neon-unknown-linux-gnueabihf": "8f546c5e857ff408fc725fc3b5df8888",
+        "wasm32-unknown-unknown": "c4a565435406998ed510ba7e3257d3cd",
     }
     return get_by_triple(HASHES, triple)
 
@@ -37,6 +39,8 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "8eccc2bf8dd958053465d3734a3bb9f7ad1e6f7721f51c6bc383625908c5e4e5",
         "x86_64-unknown-linux-gnu": "cdbe3b40cb0ef30e6768c3c8accad9c022e9b94ed75d2fb5caa8f4c7b4115d48",
         "riscv64gc-unknown-linux-gnu": "d8fa0e2cd0663e158625b73b2a9a5f2271c5ccdfb18b9cae99766220a2bef5d9",
+        "thumbv7neon-unknown-linux-gnueabihf": "1e29e4c201cee019f39d126df10bbd5a455d5b7a346174a07c149cac1611e5ad",
+        "wasm32-unknown-unknown": "517e5a9955fcd932dd66a3f6669895d7fd3aa63b1e660bd7bfe996c9c55941b5",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.75.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.75.0.bb
@@ -20,6 +20,8 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "91ee2184a667e2edb3dd01a5eead0047",
         "x86_64-unknown-linux-gnu": "ae148f391e11cc8a02b8b0ed9999354e",
         "riscv64gc-unknown-linux-gnu": "836f5455d0e7d67f0e19d7a830f27288",
+        "thumbv7neon-unknown-linux-gnueabihf": "3d4b2fd78aab3944375fa8d22ac76132",
+        "wasm32-unknown-unknown": "85a1d3150ac91d47c96b60ce6dcd1053",
     }
     return get_by_triple(HASHES, triple)
 
@@ -37,6 +39,8 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "33ab9b777d48f478992290acbb19eed2d439d49a8cb33b0681387c47f8b19801",
         "x86_64-unknown-linux-gnu": "b7a43ed4bc9a9205b3ee2ece2a38232c8da5f1f14e7ed84fbefd492f9d474579",
         "riscv64gc-unknown-linux-gnu": "bfc9b562ca488801682f62303bc9c1f429bbe66adf5eb05eb193484c75ae9a2f",
+        "thumbv7neon-unknown-linux-gnueabihf": "a4725ba7545d9f6521416be99914bb81a5bf3dc47426649b3b9f0cbab5aad1fd",
+        "wasm32-unknown-unknown": "b806e467d4334169b594807bee4006c0fad39e0320d9c29cf6948f4840a6e995",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.76.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.76.0.bb
@@ -20,6 +20,8 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "bf39759062c8c92aa7bf61d67643a7e0",
         "x86_64-unknown-linux-gnu": "b6650ab5179cbcb3423f5b900648d6c3",
         "riscv64gc-unknown-linux-gnu": "b08e98d569e56a9807513337a3e009dc",
+        "thumbv7neon-unknown-linux-gnueabihf": "2189ba28580c267dfcd77da0148304be",
+        "wasm32-unknown-unknown": "69a6a61ad009f7f548667c44e6cad424",
     }
     return get_by_triple(HASHES, triple)
 
@@ -37,6 +39,8 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "29edf8a0cc49ce5f13868cb8ac2772bde0c5e3e7e183dd9a334d4cb203cf301d",
         "x86_64-unknown-linux-gnu": "403e78b46d0730a21d6b25fe80ec947dc0ac4807c1f0930db68a4866552d839d",
         "riscv64gc-unknown-linux-gnu": "2b4c722ad1934de8908563fb7b295d050bf5e749705b9c3dc09f729d441ea64d",
+        "thumbv7neon-unknown-linux-gnueabihf": "6bbcf66e87836bed72a5071d99c3779005be7f0ef5987792ba0be6c2b4065a60",
+        "wasm32-unknown-unknown": "46ed1ff62629da8a6bf921cea2e11d8b3ba9b6bc11e44e5bc0e50b7e75dbb161",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.77.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.77.0.bb
@@ -20,6 +20,8 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "3fec7c98471104e66e2f072b1fc5d41b",
         "x86_64-unknown-linux-gnu": "5cde8a60cd76a2f6c1e3f92d96de3bea",
         "riscv64gc-unknown-linux-gnu": "f9728eb8485dca610577b909e46728fa",
+        "thumbv7neon-unknown-linux-gnueabihf": "7dbe6c5bec7d23cc06081f732bc39e6f",
+        "wasm32-unknown-unknown": "62e54013da86f1d8587d43efec8553e4",
     }
     return get_by_triple(HASHES, triple)
 
@@ -37,6 +39,8 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "5677fce99a1aedd78897aadfd8e0e1c8691f8da7de7bfed747df243341294c46",
         "x86_64-unknown-linux-gnu": "d134d44ff9feed5b6b5b686ab996d5dd188baa9b3a08a53e1587a492e2fc4704",
         "riscv64gc-unknown-linux-gnu": "7b072ab55e8ae9506958b1fcc04d46846fe2024aa1dcc4266247325ecb9983f5",
+        "thumbv7neon-unknown-linux-gnueabihf": "a39842ff68266b5338ccee1315b945637f3111dce7e1e3639191bb6af937648e",
+        "wasm32-unknown-unknown": "1287ad1cc7e9c44a969606699d72c04d15467dd72851c3c425c44a9bf8f8641b",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.77.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.77.1.bb
@@ -20,6 +20,8 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "2cc94c177812830241e09bce45e58b67",
         "x86_64-unknown-linux-gnu": "abe3cba26a5e0b02d2d7d3f7c2066a7e",
         "riscv64gc-unknown-linux-gnu": "08a0a9e3d12659366f3f9b972c62356d",
+        "thumbv7neon-unknown-linux-gnueabihf": "589ef17b75d9396d278e0806584d2052",
+        "wasm32-unknown-unknown": "219b0186cd97958c47b4fb2787ce603a",
     }
     return get_by_triple(HASHES, triple)
 
@@ -37,6 +39,8 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "dcb9be262c0ae2b893f5f691ba45823745b4de8353ab012cfd1eef030afc84d5",
         "x86_64-unknown-linux-gnu": "eed95cb4c951768eeec372c7a20f5e074837315dc0d066b4ec79620ff26f657a",
         "riscv64gc-unknown-linux-gnu": "b0fa4d4b551acb8c58f41b8b212cbc76b9e1e9ef3f35d2b30a9e364894901646",
+        "thumbv7neon-unknown-linux-gnueabihf": "484beae3fe1d1396a919ff35df9fa52c9b3872ff175dd3e3a792a41424292d21",
+        "wasm32-unknown-unknown": "aeb8e4a596933e2ea0dc857eb15a12aa85511454f9c5cc9aba5f4ec61ed91870",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.77.2.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.77.2.bb
@@ -20,6 +20,8 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "a6c4424c28548571181790984c51d311",
         "x86_64-unknown-linux-gnu": "239bb20102f6bf44378e1f72bd7395ac",
         "riscv64gc-unknown-linux-gnu": "5a076400e147d3e8165a0e0668b95bfe",
+        "thumbv7neon-unknown-linux-gnueabihf": "955392be97f1f460e636bb67c447035f",
+        "wasm32-unknown-unknown": "096dfde3977c294133883dff08fc1abd",
     }
     return get_by_triple(HASHES, triple)
 
@@ -37,6 +39,8 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "1f5550e1a7c9e4f613119d7ab4b7dd92f728f0157f720d1484dcf62d4acee70e",
         "x86_64-unknown-linux-gnu": "ee1157c43c314a19d6057cbe08b698ba29c5744eee45381ff60319fd286c7f9e",
         "riscv64gc-unknown-linux-gnu": "bcc021d4792e10aecb94ce43b25a36f569e8dab42e7c48c209c4c5337ca16d8e",
+        "thumbv7neon-unknown-linux-gnueabihf": "f8a35905d7a536b87cf631956133b9c9d55d099022869654febe6e9d1c2a8770",
+        "wasm32-unknown-unknown": "a121200b96d62e10c143f6cebaac1f1621f8cd251601bd481a906defca37d37d",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.78.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.78.0.bb
@@ -20,6 +20,8 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "0fa13301cf0cf440dbdf8bd57c67da79",
         "x86_64-unknown-linux-gnu": "81fd26e8d408547d858fb28c85e105af",
         "riscv64gc-unknown-linux-gnu": "c8c3ae553d93810d283aa5789cb90ff7",
+        "thumbv7neon-unknown-linux-gnueabihf": "23cef1382c093f42082d62e9e44b12cc",
+        "wasm32-unknown-unknown": "df7ba8adc32f30dd287794517b398aeb",
     }
     return get_by_triple(HASHES, triple)
 
@@ -37,6 +39,8 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "761b208e700fcb0088ec451a646b408020a776ab079a2ba76c816a973516c0bf",
         "x86_64-unknown-linux-gnu": "0048c9b4b0e1de3cebff9e159fe47b7a366f5c1823e71f0c984fbcacd7453a7d",
         "riscv64gc-unknown-linux-gnu": "b01c429e44f34ad44b6f280764d794f4c1e0dd316e45089d02c0ee79c62c2c47",
+        "thumbv7neon-unknown-linux-gnueabihf": "387e029d94ada45a9cb8b1dd9bb0726ba9592460df29a55a4775dbd7027d5b00",
+        "wasm32-unknown-unknown": "fe7fa3d7db7c1cc6482cf0644c19df79c97efb96441550739a25f0477b2bdcdb",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.79.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.79.0.bb
@@ -20,6 +20,8 @@ def rust_std_md5(triple):
         "powerpc-unknown-linux-gnu": "a180a1e4357e5d9b4dd674204ef377c2",
         "x86_64-unknown-linux-gnu": "489611626b01cf4f882df76e3cfe7306",
         "riscv64gc-unknown-linux-gnu": "9c207fd91907f498ae81c5bf23c48c69",
+        "thumbv7neon-unknown-linux-gnueabihf": "b7c95d423d442788e745ba62d2ea2b60",
+        "wasm32-unknown-unknown": "472df5716128f9f7988b7bfe57fbb408",
     }
     return get_by_triple(HASHES, triple)
 
@@ -37,6 +39,8 @@ def rust_std_sha256(triple):
         "powerpc-unknown-linux-gnu": "0ba4060db997a1b6bb2a06364a9e20d6c68b22c16d5e862a3673d2f447f19b80",
         "x86_64-unknown-linux-gnu": "037906a372ec87f8fd7ab45efa645bcc4fbf981f534e31534c6f16ce628fddb6",
         "riscv64gc-unknown-linux-gnu": "8578f69dff411c9afd0b1a993ac35641b9741dd901fcd680eac2789287f6c551",
+        "thumbv7neon-unknown-linux-gnueabihf": "eaeb3caf8e3d25ba7ec4b73e807848c22e60465b8c37c6f97fb040db066d0b37",
+        "wasm32-unknown-unknown": "a9335cdcd26c11cc0ba8f1f4732bbe3fd304e8b70525c534e174d65384f2cb9d",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.80.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.80.0.bb
@@ -21,6 +21,7 @@ def rust_std_md5(triple):
         "x86_64-unknown-linux-gnu": "093653b92d0f131c51d383e7f08d8af9",
         "riscv64gc-unknown-linux-gnu": "eb089351d7e9f4ea9c9ac8784034ea84",
         "thumbv7neon-unknown-linux-gnueabihf": "6a3daeb50d4ae7fc832551696ca156f2",
+        "wasm32-unknown-unknown": "939d85756ead5738d18c05cc971cbbfc",
     }
     return get_by_triple(HASHES, triple)
 
@@ -39,6 +40,7 @@ def rust_std_sha256(triple):
         "x86_64-unknown-linux-gnu": "ed301dff3a26da496784ca3de523b0150302fcb001ef71cdcd40ff6d5e2ec75d",
         "riscv64gc-unknown-linux-gnu": "08c016ed824705bfc7367613001dd6d7696e2d314767f96c224e9e8cdf998f6a",
         "thumbv7neon-unknown-linux-gnueabihf": "446bb691128f3b4d88d63c4688abaf5579846308e1b1fd86510676a58955210c",
+        "wasm32-unknown-unknown": "4afadaa8f015d55b8c0b3c7e7db6ec7c3ea0d35300405e61b9933a83b7a9b019",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.81.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.81.0.bb
@@ -21,6 +21,7 @@ def rust_std_md5(triple):
         "x86_64-unknown-linux-gnu": "a742afe895015e0c17a40d89bb4bfbde",
         "riscv64gc-unknown-linux-gnu": "a63265ae4617edec953ea5e3bdde5581",
         "thumbv7neon-unknown-linux-gnueabihf": "c2418fc081cc216596267b94739735d4",
+        "wasm32-unknown-unknown": "262b0f8962b97ae04c97318496942d00",
     }
     return get_by_triple(HASHES, triple)
 
@@ -39,6 +40,7 @@ def rust_std_sha256(triple):
         "x86_64-unknown-linux-gnu": "7c6918beb76e62dcf43294b18fabe058239e2fb9c8c04ebda3854f9f2b22df3c",
         "riscv64gc-unknown-linux-gnu": "8f92d15c1fa72f4f1228c145edd7e21744c3a54d777009545e620490926f9301",
         "thumbv7neon-unknown-linux-gnueabihf": "b8461fcb59eedb94754ff9c6439378907d04f4046e75b377ad7c818aa42703ce",
+        "wasm32-unknown-unknown": "c5363bde6d2b680e43f7fd444ea60f88cf522070de86f0a940d6570671cef94c",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.82.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.82.0.bb
@@ -21,6 +21,7 @@ def rust_std_md5(triple):
         "x86_64-unknown-linux-gnu": "9b687db3086c7f12d8d451f7906bdae4",
         "riscv64gc-unknown-linux-gnu": "962fe8a8c3f605b93222a36975fcd14e",
         "thumbv7neon-unknown-linux-gnueabihf": "5a73bcd3f5a2a4b3074c7350cc1aeda9",
+        "wasm32-unknown-unknown": "6fa86da050154db4da7e2a9e746a6950",
     }
     return get_by_triple(HASHES, triple)
 
@@ -39,6 +40,7 @@ def rust_std_sha256(triple):
         "x86_64-unknown-linux-gnu": "e7e808b8745298369fa3bbc3c0b7af9ca0fb995661bd684a7022d14bc9ae0057",
         "riscv64gc-unknown-linux-gnu": "7b35c8207c77e3fc2f7f7a26dea989cc2cdc13a955851ff74d4882f96f4e14dd",
         "thumbv7neon-unknown-linux-gnueabihf": "c940d08d695b9e72ed90efc727d8ef9e8b69aad5332e3270191974a33b1450ab",
+        "wasm32-unknown-unknown": "c0b7be8188c1539b0508e6f64c58589775674cba5f8fe997f731d399431258f1",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.83.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.83.0.bb
@@ -21,6 +21,7 @@ def rust_std_md5(triple):
         "x86_64-unknown-linux-gnu": "9077cbeb36789a6673d500e06b9ab225",
         "riscv64gc-unknown-linux-gnu": "411b42f5750d920408afd93f2eec895c",
         "thumbv7neon-unknown-linux-gnueabihf": "5fdca995b661c440c33d2b7b8ebd0639",
+        "wasm32-unknown-unknown": "5a65c7e8309c1b58af58eede65c20116",
     }
     return get_by_triple(HASHES, triple)
 
@@ -39,6 +40,7 @@ def rust_std_sha256(triple):
         "x86_64-unknown-linux-gnu": "5cca3330f713fa7279db5384890c266535d079a85cdfd1a52e69c55f291db9c4",
         "riscv64gc-unknown-linux-gnu": "40f87b810dfacb9d4661eab3380163e1f09cad33a3e466268ac1801d330eb2be",
         "thumbv7neon-unknown-linux-gnueabihf": "472ad2c9d3a1b20d7f4e9ec319324d473793908c71dd2dca9fe32bdb35d2c8d8",
+        "wasm32-unknown-unknown": "c18935bb4dfdc027d5a88ff55d3d6306fb27fe796db4e5eda8723b75a7cdb2ce",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.84.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.84.0.bb
@@ -21,6 +21,7 @@ def rust_std_md5(triple):
         "x86_64-unknown-linux-gnu": "fe23387f3c8b8b727b7102c527d17e38",
         "riscv64gc-unknown-linux-gnu": "336f16847cb94a30a90acd953d92526d",
         "thumbv7neon-unknown-linux-gnueabihf": "eb43476d9f3bdfb4c195e6fdb2584880",
+        "wasm32-unknown-unknown": "00548471f378da45352894bbedc180f0",
     }
     return get_by_triple(HASHES, triple)
 
@@ -39,6 +40,7 @@ def rust_std_sha256(triple):
         "x86_64-unknown-linux-gnu": "b3050a3b63da621f27517bd1252e976fd69ca45adf24e307627d4ca8b3efd7d7",
         "riscv64gc-unknown-linux-gnu": "8bffde598c149881bb03883469a442f95ecc58e3a05e4b6dd2cdf973fb0a5f9e",
         "thumbv7neon-unknown-linux-gnueabihf": "b66f640db796302c28732d56a505dd6ae6effa27fb0d125ef28d254f189a3e5f",
+        "wasm32-unknown-unknown": "76e74b68fa4561f94434b37e16d06e3167d5524870515e62d52a7d3c93d0dc14",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.84.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.84.1.bb
@@ -21,6 +21,7 @@ def rust_std_md5(triple):
         "x86_64-unknown-linux-gnu": "9d74abd1acd6ecb2c13e6b8fc5c76a77",
         "riscv64gc-unknown-linux-gnu": "2e79d326f8562da0744a54f65510fb25",
         "thumbv7neon-unknown-linux-gnueabihf": "b3b5207dd993d229404664130845d8bd",
+        "wasm32-unknown-unknown": "c6efa4c724c3e94c30f80d728bf1d31e",
     }
     return get_by_triple(HASHES, triple)
 
@@ -39,6 +40,7 @@ def rust_std_sha256(triple):
         "x86_64-unknown-linux-gnu": "cbf724ea079f6aae03ad619dacdd205c97bcd624077332cf6a5ddba521667e0d",
         "riscv64gc-unknown-linux-gnu": "b6c7b5e9868b08adb3ec81b903d339388762f23bcd56a9bfb10c55af7ef36537",
         "thumbv7neon-unknown-linux-gnueabihf": "4e3a0d9eb2f15a32ba06cd3645062b0a40728e4cac03a84e7c5e53c323b5f871",
+        "wasm32-unknown-unknown": "ded2f8aafed0f126d3a04a449c4e75f9d50abefeb5833ac6c7ae1142f1660549",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.85.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.85.0.bb
@@ -21,6 +21,7 @@ def rust_std_md5(triple):
         "x86_64-unknown-linux-gnu": "31acd5f8bcec9e6063139c3bd5dcf752",
         "riscv64gc-unknown-linux-gnu": "fa0814fc1f69ad1f603ea927fdfacdbf",
         "thumbv7neon-unknown-linux-gnueabihf": "b74265dd4e7b849631b3a98b767117d7",
+        "wasm32-unknown-unknown": "e89cbb54c6051165daa1ea1c194e5fab",
     }
     return get_by_triple(HASHES, triple)
 
@@ -39,6 +40,7 @@ def rust_std_sha256(triple):
         "x86_64-unknown-linux-gnu": "b3ad21966023d24fac039385201dc4109a2f25e6f7a0a5b2a0910eccfdc0c4a9",
         "riscv64gc-unknown-linux-gnu": "663607262f7e4efd0220e672a677c34c25ec5c551d405b254a02ee914a1279f1",
         "thumbv7neon-unknown-linux-gnueabihf": "9f5a01fe547b452bcc722f5b7364ec43b9e24ba40cc568524c5714bea5495897",
+        "wasm32-unknown-unknown": "c1e19115a19b074d87d5652d959951b641ffa1512a9dee10964f0f7ee19cca3c",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.85.1.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.85.1.bb
@@ -21,6 +21,7 @@ def rust_std_md5(triple):
         "x86_64-unknown-linux-gnu": "f92f11bb7106632dd7c61a25b768341c",
         "riscv64gc-unknown-linux-gnu": "6a3b2d3e29355158ead7166301fe6281",
         "thumbv7neon-unknown-linux-gnueabihf": "d0aaf616cb7977cb865d0a6327b32ea2",
+        "wasm32-unknown-unknown": "7c9c863ba4ab3741efc2c9f9c54c16b5",
     }
     return get_by_triple(HASHES, triple)
 
@@ -39,6 +40,7 @@ def rust_std_sha256(triple):
         "x86_64-unknown-linux-gnu": "3e14ec3f9f622f2b577817f71413259a401c0b233a527ef561342f3c10a777a6",
         "riscv64gc-unknown-linux-gnu": "1a24ec34fecc1330eb0dedf249ce54b06b52569c3b5e99737c509d16143dafe7",
         "thumbv7neon-unknown-linux-gnueabihf": "ac25297b3325e475fadc1d6478e78acd4d9e59f36a92c35d2bd56322a6a0b7ae",
+        "wasm32-unknown-unknown": "7cac82ca376a35118fcdefda1b5d31d14ac2c8dcb2d1e3204f0bdcfb35d488b1",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.86.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.86.0.bb
@@ -21,6 +21,7 @@ def rust_std_md5(triple):
         "x86_64-unknown-linux-gnu": "b77fcb8fa51e256ad3d525bc7d1452e1",
         "riscv64gc-unknown-linux-gnu": "359aa00a38ea897e652a8a984f48019e",
         "thumbv7neon-unknown-linux-gnueabihf": "2ec2eaa3c3c57ced4971b7e67ac345c5",
+        "wasm32-unknown-unknown": "db65e8f4eef084f9f723e2265b344ba2",
     }
     return get_by_triple(HASHES, triple)
 
@@ -39,6 +40,7 @@ def rust_std_sha256(triple):
         "x86_64-unknown-linux-gnu": "8be751af80851b9f8dd547f46e1b99e4d1bbdb226d46a796a0146cf9d354df4b",
         "riscv64gc-unknown-linux-gnu": "390db5dda189a129fc2f303aae18ff75ca441500566d4f4b516aadd6ecfc65b0",
         "thumbv7neon-unknown-linux-gnueabihf": "6a8a5ed73adbfd83ebba0d47efdc34c6bfe1344f24c84248e32bed33d89f2f29",
+        "wasm32-unknown-unknown": "51ff2cbeba9db7cda419b777e2c6cc4de96aa7ecd6d0d54a27c0f1861891d3ab",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.87.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.87.0.bb
@@ -21,6 +21,7 @@ def rust_std_md5(triple):
         "x86_64-unknown-linux-gnu": "5e2e420ec306d9f0de726ab2668cb038",
         "riscv64gc-unknown-linux-gnu": "e4281aad61372ca6aadcf83fecc42b26",
         "thumbv7neon-unknown-linux-gnueabihf": "8961accea107029188254d66333ff652",
+        "wasm32-unknown-unknown": "bdbd740abf9b7e6460a71a7360cfd610",
     }
     return get_by_triple(HASHES, triple)
 
@@ -39,6 +40,7 @@ def rust_std_sha256(triple):
         "x86_64-unknown-linux-gnu": "68e2cb00d28b42caea0d07be6fe603ef28389dfb02f19013f2c57e5783831328",
         "riscv64gc-unknown-linux-gnu": "ed54c611c8a80fb2850be077b1b3fec44ab12a65cef239a8b731a2f9630ad79c",
         "thumbv7neon-unknown-linux-gnueabihf": "15c39e11dd231a9630aa63b1b103101bfb8bc8bec14fb92da7bdca1fa852c163",
+        "wasm32-unknown-unknown": "8baa5b308c1072348bf71cf8eee0f8d270ddfcfff8eb674deb232a380d8e77dd",
     }
     return get_by_triple(HASHES, triple)
 

--- a/recipes-devtools/rust/rust-bin-cross_1.88.0.bb
+++ b/recipes-devtools/rust/rust-bin-cross_1.88.0.bb
@@ -21,6 +21,7 @@ def rust_std_md5(triple):
         "x86_64-unknown-linux-gnu": "c2b38c2a8024a90f3247c9f2b521e355",
         "riscv64gc-unknown-linux-gnu": "325f48046ae296e9d9674624f78fcf4d",
         "thumbv7neon-unknown-linux-gnueabihf": "73e65401ffcfd7df2d0188060a338827",
+        "wasm32-unknown-unknown": "325de870623f0134de225c1daf003137",
     }
     return get_by_triple(HASHES, triple)
 
@@ -39,6 +40,7 @@ def rust_std_sha256(triple):
         "x86_64-unknown-linux-gnu": "0d7967f18bbf29777843248091a4f06cdfec2500de33cbfe6b69c6af255f72b7",
         "riscv64gc-unknown-linux-gnu": "80e19f15104d13a3d03e6d53797a1317825046cf6de189621d45a5138eba082c",
         "thumbv7neon-unknown-linux-gnueabihf": "b6738024979d0a822237681dd731e73ab03d8642548d87269044e0bc18bca453",
+        "wasm32-unknown-unknown": "67d5d0c4dc978fa2fbb7e14c2e9b71ee1a16f5616e05464cda6abad1daa67b57",
     }
     return get_by_triple(HASHES, triple)
 


### PR DESCRIPTION
In order to generate wasm32 builds, you need to add `wasm32-unknown-unknown` to the `EXTRA_RUST_TARGETS` variable and then append your cargo build instructions in your recipe.