### PR TITLE
Add support for wrynose

### DIFF
--- a/classes/cargo_bin.bbclass
+++ b/classes/cargo_bin.bbclass
@@ -1,5 +1,12 @@
 inherit rust_bin-common
 
+python () {
+    if d.getVar("LAYERSERIES_COMPAT_core") == "walnascar":
+        d.setVar("COMPATIBLE_PACKDIR", d.getVar("UNPACKDIR"))
+    else:
+        d.setVar("COMPATIBLE_PACKDIR", d.getVar("WORKDIR"))
+}
+
 # Many crates rely on pkg-config to find native versions of their libraries for
 # linking - do the simple thing and make it generally available.
 DEPENDS:append = "\
@@ -8,13 +15,13 @@ DEPENDS:append = "\
 "
 
 # Move CARGO_HOME from default of ~/.cargo
-export CARGO_HOME = "${UNPACKDIR}/cargo_home"
+export CARGO_HOME = "${COMPATIBLE_PACKDIR}/cargo_home"
 
 # If something fails while building, this might give useful information
 export RUST_BACKTRACE = "1"
 
 # Do build out-of-tree
-B = "${UNPACKDIR}/target"
+B = "${COMPATIBLE_PACKDIR}/target"
 export CARGO_TARGET_DIR = "${B}"
 
 RUST_TARGET = "${@rust_target(d, 'TARGET')}"
@@ -45,7 +52,7 @@ def cargo_profile_to_builddir(profile):
     }.get(profile, profile)
 
 CARGO_BINDIR = "${B}/${RUST_TARGET}/${@cargo_profile_to_builddir(d.getVar('CARGO_BUILD_PROFILE'))}"
-WRAPPER_DIR = "${UNPACKDIR}/wrappers"
+WRAPPER_DIR = "${COMPATIBLE_PACKDIR}/wrappers"
 
 # Set the Cargo manifest path to the typical location
 CARGO_MANIFEST_PATH ?= "${S}/Cargo.toml"

--- a/classes/cargo_bin.bbclass
+++ b/classes/cargo_bin.bbclass
@@ -8,13 +8,13 @@ DEPENDS:append = "\
 "
 
 # Move CARGO_HOME from default of ~/.cargo
-export CARGO_HOME = "${WORKDIR}/cargo_home"
+export CARGO_HOME = "${UNPACKDIR}/cargo_home"
 
 # If something fails while building, this might give useful information
 export RUST_BACKTRACE = "1"
 
 # Do build out-of-tree
-B = "${WORKDIR}/target"
+B = "${UNPACKDIR}/target"
 export CARGO_TARGET_DIR = "${B}"
 
 RUST_TARGET = "${@rust_target(d, 'TARGET')}"
@@ -45,7 +45,7 @@ def cargo_profile_to_builddir(profile):
     }.get(profile, profile)
 
 CARGO_BINDIR = "${B}/${RUST_TARGET}/${@cargo_profile_to_builddir(d.getVar('CARGO_BUILD_PROFILE'))}"
-WRAPPER_DIR = "${WORKDIR}/wrappers"
+WRAPPER_DIR = "${UNPACKDIR}/wrappers"
 
 # Set the Cargo manifest path to the typical location
 CARGO_MANIFEST_PATH ?= "${S}/Cargo.toml"

--- a/classes/cargo_bin.bbclass
+++ b/classes/cargo_bin.bbclass
@@ -1,7 +1,8 @@
 inherit rust_bin-common
 
 python () {
-    if d.getVar("LAYERSERIES_COMPAT_core") == "walnascar":
+    layerseries = d.getVar("LAYERSERIES_COMPAT_core")
+    if layerseries in ["walnascar", "whinlatter"]:
         d.setVar("COMPATIBLE_PACKDIR", d.getVar("UNPACKDIR"))
     else:
         d.setVar("COMPATIBLE_PACKDIR", d.getVar("WORKDIR"))

--- a/classes/cargo_bin.bbclass
+++ b/classes/cargo_bin.bbclass
@@ -2,7 +2,7 @@ inherit rust_bin-common
 
 python () {
     layerseries = d.getVar("LAYERSERIES_COMPAT_core")
-    if layerseries in ["walnascar", "whinlatter"]:
+    if layerseries in ["walnascar", "whinlatter", "wrynose"]:
         d.setVar("COMPATIBLE_PACKDIR", d.getVar("UNPACKDIR"))
     else:
         d.setVar("COMPATIBLE_PACKDIR", d.getVar("WORKDIR"))

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,13 +11,5 @@ BBFILE_PRIORITY_rust-bin-layer = "7"
 LICENSE_PATH += "${LAYERDIR}/files/common-licenses"
 
 LAYERSERIES_COMPAT_rust-bin-layer = " \
-    dunfell \
-    gatesgarth \
-    hardknott \
-    honister \
-    kirkstone \
-    langdale \
-    mickledore \
-    nanbield \
-    scarthgap \
+ walnascar \
 "

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,5 +11,14 @@ BBFILE_PRIORITY_rust-bin-layer = "7"
 LICENSE_PATH += "${LAYERDIR}/files/common-licenses"
 
 LAYERSERIES_COMPAT_rust-bin-layer = " \
- walnascar \
+    dunfell \
+    gatesgarth \
+    hardknott \
+    honister \
+    kirkstone \
+    langdale \
+    mickledore \
+    nanbield \
+    scarthgap \
+    walnascar \
 "

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -21,4 +21,5 @@ LAYERSERIES_COMPAT_rust-bin-layer = " \
     nanbield \
     scarthgap \
     walnascar \
+    whinlatter \
 "

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -22,4 +22,5 @@ LAYERSERIES_COMPAT_rust-bin-layer = " \
     scarthgap \
     walnascar \
     whinlatter \
+    wrynose \
 "

--- a/recipes-devtools/rust/cargo-bin-cross.inc
+++ b/recipes-devtools/rust/cargo-bin-cross.inc
@@ -6,6 +6,15 @@ SECTION = "devel"
 inherit cross
 inherit rust_bin-common
 
+python () {
+    if d.getVar("LAYERSERIES_COMPAT_core") == "walnascar":
+        d.setVar("COMPATIBLE_PACKDIR", d.getVar("UNPACKDIR"))
+        d.setVar("COMPATIBLE_PACKDIR_string", "UNPACKDIR")
+    else:
+        d.setVar("COMPATIBLE_PACKDIR", d.getVar("WORKDIR"))
+        d.setVar("COMPATIBLE_PACKDIR_string", "WORKDIR")
+}
+
 PN = "cargo-bin-cross-${TARGET_ARCH}"
 
 PROVIDES += "cargo-bin-native"
@@ -47,7 +56,7 @@ python () {
     src_uri = d.getVar("SRC_URI", True).split()
     cargo_extract_path = cargo_url(target).split('/')[-1].replace('.tar.gz', '')
     d.setVar("SRC_URI", ' '.join(src_uri + [cargo_uri]))
-    d.setVar("S", "${{UNPACKDIR}}/{}".format(cargo_extract_path))
+    d.setVar("S", "${{COMPATIBLE_PACKDIR}}/{}".format(cargo_extract_path))
     d.appendVarFlag("S", "vardeps", " cargo_url")
-    d.appendVarFlag("S", "vardepsexclude", " UNPACKDIR")
+    d.appendVarFlag("S", "vardepsexclude", " ${COMPATIBLE_PACKDIR_string}")
 }

--- a/recipes-devtools/rust/cargo-bin-cross.inc
+++ b/recipes-devtools/rust/cargo-bin-cross.inc
@@ -47,7 +47,7 @@ python () {
     src_uri = d.getVar("SRC_URI", True).split()
     cargo_extract_path = cargo_url(target).split('/')[-1].replace('.tar.gz', '')
     d.setVar("SRC_URI", ' '.join(src_uri + [cargo_uri]))
-    d.setVar("S", "${{WORKDIR}}/{}".format(cargo_extract_path))
+    d.setVar("S", "${{UNPACKDIR}}/{}".format(cargo_extract_path))
     d.appendVarFlag("S", "vardeps", " cargo_url")
-    d.appendVarFlag("S", "vardepsexclude", " WORKDIR")
+    d.appendVarFlag("S", "vardepsexclude", " UNPACKDIR")
 }

--- a/recipes-devtools/rust/cargo-bin-cross.inc
+++ b/recipes-devtools/rust/cargo-bin-cross.inc
@@ -7,7 +7,8 @@ inherit cross
 inherit rust_bin-common
 
 python () {
-    if d.getVar("LAYERSERIES_COMPAT_core") == "walnascar":
+    layerseries = d.getVar("LAYERSERIES_COMPAT_core")
+    if layerseries in ["walnascar", "whinlatter"]:
         d.setVar("COMPATIBLE_PACKDIR", d.getVar("UNPACKDIR"))
         d.setVar("COMPATIBLE_PACKDIR_string", "UNPACKDIR")
     else:

--- a/recipes-devtools/rust/cargo-bin-cross.inc
+++ b/recipes-devtools/rust/cargo-bin-cross.inc
@@ -8,7 +8,7 @@ inherit rust_bin-common
 
 python () {
     layerseries = d.getVar("LAYERSERIES_COMPAT_core")
-    if layerseries in ["walnascar", "whinlatter"]:
+    if layerseries in ["walnascar", "whinlatter", "wrynose"]:
         d.setVar("COMPATIBLE_PACKDIR", d.getVar("UNPACKDIR"))
         d.setVar("COMPATIBLE_PACKDIR_string", "UNPACKDIR")
     else:

--- a/recipes-devtools/rust/rust-bin-cross.inc
+++ b/recipes-devtools/rust/rust-bin-cross.inc
@@ -6,6 +6,15 @@ SECTION = "devel"
 inherit cross
 inherit rust_bin-common
 
+python () {
+    if d.getVar("LAYERSERIES_COMPAT_core") == "walnascar":
+        d.setVar("COMPATIBLE_PACKDIR", d.getVar("UNPACKDIR"))
+        d.setVar("COMPATIBLE_PACKDIR_string", "UNPACKDIR")
+    else:
+        d.setVar("COMPATIBLE_PACKDIR", d.getVar("WORKDIR"))
+        d.setVar("COMPATIBLE_PACKDIR_string", "WORKDIR")
+}
+
 PN:class-native = "rust-bin-native-${BUILD_ARCH}"
 
 # Required to link binaries
@@ -27,14 +36,14 @@ def get_s(d):
     nightly = pv.startswith("nightly-")
 
     if nightly:
-        return "${UNPACKDIR}/rustc-nightly-${RUST_BUILD_TARGET}"
+        return "${COMPATIBLE_PACKDIR}/rustc-nightly-${RUST_BUILD_TARGET}"
     else:
-        return "${UNPACKDIR}/rustc-${PV}-${RUST_BUILD_TARGET}"
+        return "${COMPATIBLE_PACKDIR}/rustc-${PV}-${RUST_BUILD_TARGET}"
   
 S = "${@get_s(d)}"
 
-# Relocating UNPACKDIR doesn't matter to installer
-S[vardepsexclude] += "UNPACKDIR"
+# Relocating UNPACKDIR/WORKDIR doesn't matter to installer
+S[vardepsexclude] += "${COMPATIBLE_PACKDIR_string}"
 
 SYSROOT_DIRS_NATIVE += "${prefix}"
 SYSROOT_DIRS_IGNORE += "\
@@ -51,7 +60,7 @@ fakeroot do_install() {
     ${S}/install.sh --destdir="${D}" --prefix="${prefix}"
 
     # Install rust standard libraries
-    cd ${UNPACKDIR}/rust-std
+    cd ${COMPATIBLE_PACKDIR}/rust-std
     for subdir in *; do
         $subdir/install.sh --destdir="${D}" --prefix="${prefix}"
     done

--- a/recipes-devtools/rust/rust-bin-cross.inc
+++ b/recipes-devtools/rust/rust-bin-cross.inc
@@ -27,14 +27,14 @@ def get_s(d):
     nightly = pv.startswith("nightly-")
 
     if nightly:
-        return "${WORKDIR}/rustc-nightly-${RUST_BUILD_TARGET}"
+        return "${UNPACKDIR}/rustc-nightly-${RUST_BUILD_TARGET}"
     else:
-        return "${WORKDIR}/rustc-${PV}-${RUST_BUILD_TARGET}"
+        return "${UNPACKDIR}/rustc-${PV}-${RUST_BUILD_TARGET}"
   
 S = "${@get_s(d)}"
 
-# Relocating WORKDIR doesn't matter to installer
-S[vardepsexclude] += "WORKDIR"
+# Relocating UNPACKDIR doesn't matter to installer
+S[vardepsexclude] += "UNPACKDIR"
 
 SYSROOT_DIRS_NATIVE += "${prefix}"
 SYSROOT_DIRS_IGNORE += "\
@@ -51,7 +51,7 @@ fakeroot do_install() {
     ${S}/install.sh --destdir="${D}" --prefix="${prefix}"
 
     # Install rust standard libraries
-    cd ${WORKDIR}/rust-std
+    cd ${UNPACKDIR}/rust-std
     for subdir in *; do
         $subdir/install.sh --destdir="${D}" --prefix="${prefix}"
     done

--- a/recipes-devtools/rust/rust-bin-cross.inc
+++ b/recipes-devtools/rust/rust-bin-cross.inc
@@ -7,7 +7,8 @@ inherit cross
 inherit rust_bin-common
 
 python () {
-    if d.getVar("LAYERSERIES_COMPAT_core") == "walnascar":
+    layerseries = d.getVar("LAYERSERIES_COMPAT_core")
+    if layerseries in ["walnascar", "whinlatter"]:
         d.setVar("COMPATIBLE_PACKDIR", d.getVar("UNPACKDIR"))
         d.setVar("COMPATIBLE_PACKDIR_string", "UNPACKDIR")
     else:

--- a/recipes-devtools/rust/rust-bin-cross.inc
+++ b/recipes-devtools/rust/rust-bin-cross.inc
@@ -8,7 +8,7 @@ inherit rust_bin-common
 
 python () {
     layerseries = d.getVar("LAYERSERIES_COMPAT_core")
-    if layerseries in ["walnascar", "whinlatter"]:
+    if layerseries in ["walnascar", "whinlatter", "wrynose"]:
         d.setVar("COMPATIBLE_PACKDIR", d.getVar("UNPACKDIR"))
         d.setVar("COMPATIBLE_PACKDIR_string", "UNPACKDIR")
     else:


### PR DESCRIPTION
Closes #238.

This builds on #232 (which in turn builds on #228), and simply adds `wrynose` into the list that uses `UNPACKDIR`. Tested with yocto 6.